### PR TITLE
Add overlay canvas support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Muscle and Blood 3</title>
-    <link rel="stylesheet" href="style.css"> </head>
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
-    <canvas id="gameCanvas"></canvas>
+    <div id="game-container">
+        <canvas id="gameCanvas"></canvas>
+        <canvas id="mercenaryPanelCanvas" class="overlay-canvas"></canvas>
+        <canvas id="combatLogCanvas" class="overlay-canvas"></canvas>
+    </div>
 
-    <script src="resolutionEngine.js"></script>
-    <script src="measurementEngine.js"></script>
-    <script src="gameEngine.js"></script>
-    <script src="renderer.js"></script>
-    <script src="gameLoop.js"></script>
-    <script src="main.js"></script>
+    <script src="js/resolutionEngine.js"></script>
+    <script src="js/measurementEngine.js"></script>
+    <script src="js/gameEngine.js"></script>
+    <script src="js/renderer.js"></script>
+    <script src="js/gameLoop.js"></script>
+    <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -8,9 +8,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const resolutionEngine = new ResolutionEngine('gameCanvas', 1920, 1080);
     const gl = resolutionEngine.getGLContext();
 
+    // 새롭게 추가된 오버레이 캔버스들에 대한 WebGL 컨텍스트 초기화
+    const mercenaryPanelCanvas = document.getElementById('mercenaryPanelCanvas');
+    const mercenaryPanelGl = mercenaryPanelCanvas ?
+        mercenaryPanelCanvas.getContext('webgl', { alpha: true, antialias: true }) : null;
+
+    const combatLogCanvas = document.getElementById('combatLogCanvas');
+    const combatLogGl = combatLogCanvas ?
+        combatLogCanvas.getContext('webgl', { alpha: true, antialias: true }) : null;
+
     if (!gl) {
-        console.error("Failed to get WebGL context. Game cannot run.");
+        console.error("Failed to get main WebGL context. Game cannot run.");
         return;
+    }
+    if (!mercenaryPanelGl) {
+        console.warn("Failed to get mercenary panel WebGL context.");
+    }
+    if (!combatLogGl) {
+        console.warn("Failed to get combat log WebGL context.");
     }
 
     // 2. 측량 엔진 초기화
@@ -21,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 4. 렌더러 초기화
     const renderer = new Renderer(resolutionEngine, measurementEngine);
+    // 추가 패널 컨텍스트를 렌더러에 등록하여 관리할 수 있도록 함
+    renderer.addPanelContext('mercenary', mercenaryPanelGl, mercenaryPanelCanvas);
+    renderer.addPanelContext('combatLog', combatLogGl, combatLogCanvas);
 
     // 5. 게임 루프 초기화
     const gameLoop = new GameLoop(gameEngine, renderer);


### PR DESCRIPTION
## Summary
- add container and overlay canvases in HTML
- initialize new canvas contexts in main.js
- extend renderer to manage multiple WebGL contexts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68745e2491d08327aed4367bf813e293