### PR TITLE
Integrate grid and battle stage systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,11 @@
     <script src="js/managers/uiEngine.js"></script>
     <script src="js/managers/turnEngine.js"></script>
     <script src="js/managers/delayEngine.js"></script>
+    <script src="js/managers/gridEngine.js"></script>
+    <script src="js/managers/battleLogEngine.js"></script>
+    <script src="js/managers/battleGridManager.js"></script>
+    <script src="js/managers/mercenaryPanelGridManager.js"></script>
+    <script src="js/managers/battleStageManager.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/gameLoop.js
+++ b/js/gameLoop.js
@@ -1,13 +1,16 @@
 // gameLoop.js
 
 class GameLoop {
-    constructor(gameEngine, renderer) {
+    constructor(gameEngine, renderer, panelEngine = null, uiEngine = null, delayEngine = null) {
         if (!gameEngine || !renderer) {
             console.error("GameEngine and Renderer instances are required for GameLoop.");
             return;
         }
         this.gameEngine = gameEngine;
         this.renderer = renderer;
+        this.panelEngine = panelEngine;
+        this.uiEngine = uiEngine;
+        this.delayEngine = delayEngine;
         this.lastTime = 0;
         this.isRunning = false;
 
@@ -38,6 +41,9 @@ class GameLoop {
 
         // 1. 게임 로직 업데이트
         this.gameEngine.update(deltaTime);
+        if (this.panelEngine) this.panelEngine.update(deltaTime);
+        if (this.uiEngine) this.uiEngine.update(deltaTime);
+        if (this.delayEngine) this.delayEngine.update(deltaTime);
 
         // 2. 게임 상태 렌더링
         this.renderer.render(this.gameEngine.getGameState(), deltaTime);

--- a/js/managers/battleGridManager.js
+++ b/js/managers/battleGridManager.js
@@ -1,0 +1,68 @@
+class BattleGridManager {
+    constructor(gridEngine, cameraEngine, measurementEngine, resolutionEngine) {
+        if (!gridEngine || !cameraEngine || !measurementEngine || !resolutionEngine) {
+            console.error('GridEngine, CameraEngine, MeasurementEngine, and ResolutionEngine instances are required for BattleGridManager.');
+            return;
+        }
+        this.gridEngine = gridEngine;
+        this.camera = cameraEngine;
+        this.measure = measurementEngine;
+        this.res = resolutionEngine;
+        this.gl = this.res.getGLContext();
+
+        this.gridRows = 15;
+        this.gridCols = 15;
+
+        this.horizontalPaddingRatio = 0.1;
+        this.verticalPaddingRatio = 0.15;
+
+        this.gridRect = this._calculateGridRect();
+
+        console.log('BattleGridManager initialized.');
+    }
+
+    _calculateGridRect() {
+        const internalWidth = this.res.getInternalResolution().width;
+        const internalHeight = this.res.getInternalResolution().height;
+
+        const padX = internalWidth * this.horizontalPaddingRatio;
+        const padY = internalHeight * this.verticalPaddingRatio;
+
+        const gridX = padX;
+        const gridY = padY;
+        const gridWidth = internalWidth - padX * 2;
+        const gridHeight = internalHeight - padY * 2;
+
+        return { x: gridX, y: gridY, width: gridWidth, height: gridHeight };
+    }
+
+    render(deltaTime) {
+        if (!this.gl) {
+            console.warn('BattleGridManager: WebGL context not available for rendering grid.');
+            return;
+        }
+        this.gridRect = this._calculateGridRect();
+
+        this.gridEngine.drawGrid(this.gl, {
+            x: this.gridRect.x,
+            y: this.gridRect.y,
+            width: this.gridRect.width,
+            height: this.gridRect.height,
+            rows: this.gridRows,
+            cols: this.gridCols,
+            lineColor: [0.7, 0.7, 0.7, 0.5],
+            lineWidth: 2.0,
+            camera: this.camera
+        });
+    }
+
+    getGridCellWorldPosition(row, col) {
+        const cellWidth = this.gridRect.width / this.gridCols;
+        const cellHeight = this.gridRect.height / this.gridRows;
+
+        const worldX = this.gridRect.x + col * cellWidth;
+        const worldY = this.gridRect.y + row * cellHeight;
+
+        return { x: worldX, y: worldY, width: cellWidth, height: cellHeight };
+    }
+}

--- a/js/managers/battleLogEngine.js
+++ b/js/managers/battleLogEngine.js
@@ -1,0 +1,62 @@
+class BattleLogEngine {
+    constructor(panelEngine, measurementEngine) {
+        if (!panelEngine || !measurementEngine) {
+            console.error('PanelEngine and MeasurementEngine instances are required for BattleLogEngine.');
+            return;
+        }
+        this.panelEngine = panelEngine;
+        this.measure = measurementEngine;
+        this.logMessages = [];
+        this.maxMessages = 10;
+        this.logCanvasId = 'combatLogCanvas';
+
+        this.logPanel = this.panelEngine.registerPanel(this.logCanvasId, {}, false);
+
+        if (this.logPanel) {
+            this.ctx = this.logPanel.canvas.getContext('2d');
+            this.logPanel.render = this.render.bind(this);
+            this.logPanel.update = this.update.bind(this);
+        } else {
+            console.error(`BattleLogEngine: Failed to register or get panel '${this.logCanvasId}'.`);
+        }
+
+        console.log('BattleLogEngine initialized.');
+    }
+
+    addLog(message, color = '#eee') {
+        const timestamp = Date.now();
+        this.logMessages.push({ message, color, timestamp });
+        if (this.logMessages.length > this.maxMessages) {
+            this.logMessages.shift();
+        }
+        console.log(`[BATTLE LOG] ${message}`);
+    }
+
+    update(deltaTime) {
+        // Future fade out logic can be placed here
+    }
+
+    render(glOrCtx, deltaTime) {
+        const ctx = this.ctx;
+        if (!ctx || !this.logPanel || !this.logPanel.options.isVisible) return;
+
+        const panelWidth = ctx.canvas.width;
+        const panelHeight = ctx.canvas.height;
+
+        ctx.clearRect(0, 0, panelWidth, panelHeight);
+
+        ctx.font = `${this.measure.getFontSizeSmall()}px Arial`;
+        ctx.textBaseline = 'bottom';
+
+        const padding = this.measure.getPadding('y');
+        let currentY = panelHeight - padding;
+
+        for (let i = this.logMessages.length - 1; i >= 0; i--) {
+            const log = this.logMessages[i];
+            ctx.fillStyle = log.color;
+            ctx.fillText(log.message, this.measure.getPadding('x'), currentY);
+            currentY -= this.measure.getFontSizeSmall() + padding / 2;
+            if (currentY < padding) break;
+        }
+    }
+}

--- a/js/managers/battleStageManager.js
+++ b/js/managers/battleStageManager.js
@@ -1,0 +1,54 @@
+class BattleStageManager {
+    constructor(assetLoader, renderer, cameraEngine, resolutionEngine) {
+        if (!assetLoader || !renderer || !cameraEngine || !resolutionEngine) {
+            console.error('AssetLoader, Renderer, CameraEngine, and ResolutionEngine instances are required for BattleStageManager.');
+            return;
+        }
+        this.assetLoader = assetLoader;
+        this.renderer = renderer;
+        this.camera = cameraEngine;
+        this.res = resolutionEngine;
+        this.gl = this.res.getGLContext();
+
+        this.backgroundAssetId = 'battle_stage_forest';
+        this.backgroundUrl = 'assets/images/battle-stage-forest.png';
+
+        this.isLoaded = false;
+
+        console.log('BattleStageManager initialized.');
+    }
+
+    onAssetsLoaded() {
+        if (this.assetLoader.getAsset(this.backgroundAssetId)) {
+            this.isLoaded = true;
+            console.log(`BattleStageManager: Background image '${this.backgroundAssetId}' loaded.`);
+        } else {
+            console.error(`BattleStageManager: Background image '${this.backgroundAssetId}' not found after loading.`);
+        }
+    }
+
+    render(deltaTime) {
+        if (!this.gl || !this.isLoaded) {
+            return;
+        }
+
+        const backgroundAsset = this.assetLoader.getAsset(this.backgroundAssetId);
+        if (!backgroundAsset || !backgroundAsset.texture) {
+            console.warn('BattleStageManager: Background texture not available.');
+            return;
+        }
+
+        const internalWidth = this.res.getInternalResolution().width;
+        const internalHeight = this.res.getInternalResolution().height;
+
+        this.renderer.drawTextureRect(
+            this.gl,
+            backgroundAsset.texture,
+            0,
+            0,
+            internalWidth,
+            internalHeight,
+            this.camera
+        );
+    }
+}

--- a/js/managers/gridEngine.js
+++ b/js/managers/gridEngine.js
@@ -1,0 +1,124 @@
+class GridEngine {
+    constructor(measurementEngine) {
+        if (!measurementEngine) {
+            console.error("MeasurementEngine instance is required for GridEngine.");
+            return;
+        }
+        this.measure = measurementEngine;
+        console.log('GridEngine initialized.');
+    }
+
+    /**
+     * Draw grid lines on the given WebGL context.
+     * @param {WebGLRenderingContext} gl
+     * @param {Object} options
+     */
+    drawGrid(gl, options) {
+        const {
+            x, y, width, height, rows, cols,
+            lineColor = [0.5, 0.5, 0.5, 1.0],
+            lineWidth = 1.0,
+            camera = null
+        } = options;
+
+        if (!gl) {
+            console.warn('GridEngine: No WebGL context provided for drawing grid.');
+            return;
+        }
+
+        const startX = this.measure.getPixelX(x);
+        const startY = this.measure.getPixelY(y);
+        const gridWidth = this.measure.getPixelX(width);
+        const gridHeight = this.measure.getPixelY(height);
+        const pixelLineWidth = this.measure.getPixelSize(lineWidth);
+
+        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+        const shaderProgram = gl.getParameter(gl.CURRENT_PROGRAM);
+        if (!shaderProgram) {
+            console.error('GridEngine: No active WebGL shader program found. Cannot draw grid lines.');
+            return;
+        }
+        gl.useProgram(shaderProgram);
+
+        const projectionMatrixLocation = gl.getUniformLocation(shaderProgram, 'u_projectionMatrix');
+        const viewMatrixLocation = gl.getUniformLocation(shaderProgram, 'u_viewMatrix');
+        const modelMatrixLocation = gl.getUniformLocation(shaderProgram, 'u_modelMatrix');
+        const colorLocation = gl.getUniformLocation(shaderProgram, 'u_color');
+        const positionAttributeLocation = gl.getAttribLocation(shaderProgram, 'a_position');
+
+        let projectionMatrix, viewMatrix;
+        if (camera) {
+            projectionMatrix = camera.getProjectionMatrix();
+            viewMatrix = camera.getViewMatrix();
+        } else {
+            projectionMatrix = this._createOrthographicMatrix(0, gl.canvas.width, gl.canvas.height, 0, -1, 1);
+            viewMatrix = mat4.identity();
+        }
+
+        gl.uniformMatrix4fv(projectionMatrixLocation, false, projectionMatrix);
+        gl.uniformMatrix4fv(viewMatrixLocation, false, viewMatrix);
+        gl.uniform4fv(colorLocation, lineColor);
+
+        gl.lineWidth(pixelLineWidth);
+
+        const positions = [];
+
+        const rowHeight = gridHeight / rows;
+        for (let i = 0; i <= rows; i++) {
+            const yPos = startY + i * rowHeight;
+            positions.push(startX, yPos);
+            positions.push(startX + gridWidth, yPos);
+        }
+
+        const colWidth = gridWidth / cols;
+        for (let i = 0; i <= cols; i++) {
+            const xPos = startX + i * colWidth;
+            positions.push(xPos, startY);
+            positions.push(xPos, startY + gridHeight);
+        }
+
+        const positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+        gl.vertexAttribPointer(positionAttributeLocation, 2, gl.FLOAT, false, 0, 0);
+
+        const modelMatrix = mat4.identity();
+        gl.uniformMatrix4fv(modelMatrixLocation, false, modelMatrix);
+
+        gl.drawArrays(gl.LINES, 0, positions.length / 2);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.lineWidth(1.0);
+    }
+
+    _createOrthographicMatrix(left, right, bottom, top, near, far) {
+        const matrix = new Float32Array(16);
+        const lr = 1 / (left - right);
+        const bt = 1 / (bottom - top);
+        const nf = 1 / (near - far);
+
+        matrix[0] = -2 * lr;
+        matrix[1] = 0;
+        matrix[2] = 0;
+        matrix[3] = 0;
+
+        matrix[4] = 0;
+        matrix[5] = -2 * bt;
+        matrix[6] = 0;
+        matrix[7] = 0;
+
+        matrix[8] = 0;
+        matrix[9] = 0;
+        matrix[10] = 2 * nf;
+        matrix[11] = 0;
+
+        matrix[12] = (left + right) * lr;
+        matrix[13] = (top + bottom) * bt;
+        matrix[14] = (far + near) * nf;
+        matrix[15] = 1;
+
+        return matrix;
+    }
+}

--- a/js/managers/mercenaryPanelGridManager.js
+++ b/js/managers/mercenaryPanelGridManager.js
@@ -1,0 +1,64 @@
+class MercenaryPanelGridManager {
+    constructor(gridEngine, panelEngine, measurementEngine) {
+        if (!gridEngine || !panelEngine || !measurementEngine) {
+            console.error('GridEngine, PanelEngine, and MeasurementEngine instances are required for MercenaryPanelGridManager.');
+            return;
+        }
+        this.gridEngine = gridEngine;
+        this.panelEngine = panelEngine;
+        this.measure = measurementEngine;
+
+        this.panelId = 'mercenaryPanelCanvas';
+        this.gridRows = 2;
+        this.gridCols = 6;
+
+        this.mercenaryPanel = this.panelEngine.getPanel(this.panelId);
+        if (this.mercenaryPanel) {
+            const originalRender = this.mercenaryPanel.render;
+            this.mercenaryPanel.render = (glOrCtx, deltaTime) => {
+                originalRender(glOrCtx, deltaTime);
+                this.renderGrid(glOrCtx, deltaTime);
+            };
+        } else {
+            console.error(`MercenaryPanelGridManager: Panel '${this.panelId}' not found.`);
+        }
+
+        console.log('MercenaryPanelGridManager initialized.');
+    }
+
+    renderGrid(gl, deltaTime) {
+        if (!gl || !this.mercenaryPanel || !this.mercenaryPanel.options.isVisible) {
+            return;
+        }
+
+        const panelWidth = this.mercenaryPanel.canvas.width;
+        const panelHeight = this.mercenaryPanel.canvas.height;
+
+        this.gridEngine.drawGrid(gl, {
+            x: 0,
+            y: 0,
+            width: panelWidth,
+            height: panelHeight,
+            rows: this.gridRows,
+            cols: this.gridCols,
+            lineColor: [1.0, 1.0, 0.0, 0.7],
+            lineWidth: 1.5,
+            camera: null
+        });
+    }
+
+    getGridCellPanelPosition(row, col) {
+        if (!this.mercenaryPanel) return null;
+
+        const panelInternalWidth = this.mercenaryPanel.options.width;
+        const panelInternalHeight = this.mercenaryPanel.options.height;
+
+        const cellWidth = panelInternalWidth / this.gridCols;
+        const cellHeight = panelInternalHeight / this.gridRows;
+
+        const x = col * cellWidth;
+        const y = row * cellHeight;
+
+        return { x, y, width: cellWidth, height: cellHeight };
+    }
+}

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -13,25 +13,42 @@ class Renderer {
         this.panels = panelEngine;
         this.ui = uiEngine;
 
+        this.battleGridManager = null;
+        this.battleStageManager = null;
+
         this.gl = this.res.getGLContext();
         this.internalRes = this.res.getInternalResolution();
 
         this.panelContexts = {};
 
+        this.shaderPrograms = {};
+        this.currentProgram = null;
+
         this.initWebGL();
+
+        this.rectPositionBuffer = this.gl.createBuffer();
+        this.texCoordBuffer = this.gl.createBuffer();
+        this._setupRectBuffer();
+
         console.log('Renderer initialized.');
     }
 
+    setBattleGridManager(manager) {
+        this.battleGridManager = manager;
+    }
+
+    setBattleStageManager(manager) {
+        this.battleStageManager = manager;
+    }
+
     addPanelContext(name, glContext, canvasElement) {
-        this.panelContexts[name] = {
-            gl: glContext,
-            canvas: canvasElement
-        };
+        this.panelContexts[name] = { gl: glContext, canvas: canvasElement };
         console.log(`Added panel context: ${name}`);
     }
 
     initWebGL() {
-        const vsSource = `
+        this.shaderPrograms.colorShader = this.createShaderSet(
+            `
             attribute vec2 a_position;
             uniform mat4 u_projectionMatrix;
             uniform mat4 u_viewMatrix;
@@ -39,30 +56,69 @@ class Renderer {
             void main() {
                 gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * vec4(a_position, 0.0, 1.0);
             }
-        `;
-
-        const fsSource = `
+            `,
+            `
             precision mediump float;
             uniform vec4 u_color;
             void main() {
                 gl_FragColor = u_color;
             }
-        `;
+            `,
+            ['a_position'], ['u_projectionMatrix', 'u_viewMatrix', 'u_modelMatrix', 'u_color']
+        );
 
+        this.shaderPrograms.textureShader = this.createShaderSet(
+            `
+            attribute vec2 a_position;
+            attribute vec2 a_texCoord;
+            uniform mat4 u_projectionMatrix;
+            uniform mat4 u_viewMatrix;
+            uniform mat4 u_modelMatrix;
+            varying vec2 v_texCoord;
+            void main() {
+                gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * vec4(a_position, 0.0, 1.0);
+                v_texCoord = a_texCoord;
+            }
+            `,
+            `
+            precision mediump float;
+            varying vec2 v_texCoord;
+            uniform sampler2D u_sampler;
+            void main() {
+                gl_FragColor = texture2D(u_sampler, v_texCoord);
+            }
+            `,
+            ['a_position', 'a_texCoord'], ['u_projectionMatrix', 'u_viewMatrix', 'u_modelMatrix', 'u_sampler']
+        );
+
+        this.useProgram(this.shaderPrograms.colorShader.program);
+
+        console.log('Main WebGL initialized with basic color and texture shaders.');
+    }
+
+    createShaderSet(vsSource, fsSource, attributes, uniforms) {
         const vertexShader = this.createShader(this.gl.VERTEX_SHADER, vsSource);
         const fragmentShader = this.createShader(this.gl.FRAGMENT_SHADER, fsSource);
-        this.shaderProgram = this.createProgram(vertexShader, fragmentShader);
-        this.gl.useProgram(this.shaderProgram);
+        const program = this.createProgram(vertexShader, fragmentShader);
 
-        this.projectionMatrixLocation = this.gl.getUniformLocation(this.shaderProgram, 'u_projectionMatrix');
-        this.viewMatrixLocation = this.gl.getUniformLocation(this.shaderProgram, 'u_viewMatrix');
-        this.modelMatrixLocation = this.gl.getUniformLocation(this.shaderProgram, 'u_modelMatrix');
-        this.colorLocation = this.gl.getUniformLocation(this.shaderProgram, 'u_color');
+        const attribLocations = {};
+        attributes.forEach(attr => {
+            attribLocations[attr] = this.gl.getAttribLocation(program, attr);
+        });
 
-        this.positionAttributeLocation = this.gl.getAttribLocation(this.shaderProgram, 'a_position');
-        this.gl.enableVertexAttribArray(this.positionAttributeLocation);
+        const uniformLocations = {};
+        uniforms.forEach(uni => {
+            uniformLocations[uni] = this.gl.getUniformLocation(program, uni);
+        });
 
-        console.log('Main WebGL initialized with basic shaders and uniforms.');
+        return { program, attribLocations, uniformLocations };
+    }
+
+    useProgram(program) {
+        if (this.currentProgram !== program) {
+            this.gl.useProgram(program);
+            this.currentProgram = program;
+        }
     }
 
     createShader(type, source) {
@@ -89,33 +145,132 @@ class Renderer {
         return program;
     }
 
+    _setupRectBuffer() {
+        const positions = [0, 1, 0, 0, 1, 1, 1, 0];
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.rectPositionBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(positions), this.gl.STATIC_DRAW);
+
+        const texCoords = [0, 1, 0, 0, 1, 1, 1, 0];
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.texCoordBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(texCoords), this.gl.STATIC_DRAW);
+    }
+
+    drawColorRect(gl, x, y, width, height, color, camera = null) {
+        this.useProgram(this.shaderPrograms.colorShader.program);
+        const { attribLocations, uniformLocations } = this.shaderPrograms.colorShader;
+
+        let projectionMatrix, viewMatrix;
+        if (camera) {
+            projectionMatrix = camera.getProjectionMatrix();
+            viewMatrix = camera.getViewMatrix();
+        } else {
+            projectionMatrix = this._createOrthographicMatrix(0, gl.canvas.width, gl.canvas.height, 0, -1, 1);
+            viewMatrix = mat4.identity();
+        }
+
+        gl.uniformMatrix4fv(uniformLocations['u_projectionMatrix'], false, projectionMatrix);
+        gl.uniformMatrix4fv(uniformLocations['u_viewMatrix'], false, viewMatrix);
+        gl.uniform4fv(uniformLocations['u_color'], color);
+
+        const modelMatrix = mat4.identity();
+        mat4.translate(modelMatrix, modelMatrix, [x, y, 0]);
+        mat4.scale(modelMatrix, modelMatrix, [width, height, 1]);
+        gl.uniformMatrix4fv(uniformLocations['u_modelMatrix'], false, modelMatrix);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.rectPositionBuffer);
+        gl.vertexAttribPointer(attribLocations['a_position'], 2, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(attribLocations['a_position']);
+
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+        gl.disableVertexAttribArray(attribLocations['a_position']);
+    }
+
+    drawTextureRect(gl, texture, x, y, width, height, camera = null) {
+        this.useProgram(this.shaderPrograms.textureShader.program);
+        const { attribLocations, uniformLocations } = this.shaderPrograms.textureShader;
+
+        let projectionMatrix, viewMatrix;
+        if (camera) {
+            projectionMatrix = camera.getProjectionMatrix();
+            viewMatrix = camera.getViewMatrix();
+        } else {
+            projectionMatrix = this._createOrthographicMatrix(0, gl.canvas.width, gl.canvas.height, 0, -1, 1);
+            viewMatrix = mat4.identity();
+        }
+
+        gl.uniformMatrix4fv(uniformLocations['u_projectionMatrix'], false, projectionMatrix);
+        gl.uniformMatrix4fv(uniformLocations['u_viewMatrix'], false, viewMatrix);
+
+        const modelMatrix = mat4.identity();
+        mat4.translate(modelMatrix, modelMatrix, [x, y, 0]);
+        mat4.scale(modelMatrix, modelMatrix, [width, height, 1]);
+        gl.uniformMatrix4fv(uniformLocations['u_modelMatrix'], false, modelMatrix);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.uniform1i(uniformLocations['u_sampler'], 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.rectPositionBuffer);
+        gl.vertexAttribPointer(attribLocations['a_position'], 2, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(attribLocations['a_position']);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.vertexAttribPointer(attribLocations['a_texCoord'], 2, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(attribLocations['a_texCoord']);
+
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+        gl.disableVertexAttribArray(attribLocations['a_position']);
+        gl.disableVertexAttribArray(attribLocations['a_texCoord']);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+    }
+
+    _createOrthographicMatrix(left, right, bottom, top, near, far) {
+        const matrix = new Float32Array(16);
+        const lr = 1 / (left - right);
+        const bt = 1 / (bottom - top);
+        const nf = 1 / (near - far);
+        matrix[0] = -2 * lr; matrix[1] = 0; matrix[2] = 0; matrix[3] = 0;
+        matrix[4] = 0; matrix[5] = -2 * bt; matrix[6] = 0; matrix[7] = 0;
+        matrix[8] = 0; matrix[9] = 0; matrix[10] = 2 * nf; matrix[11] = 0;
+        matrix[12] = (left + right) * lr; matrix[13] = (top + bottom) * bt; matrix[14] = (far + near) * nf; matrix[15] = 1;
+        return matrix;
+    }
+
     render(gameState, deltaTime) {
         this.res.beginFrame();
-        this.gl.useProgram(this.shaderProgram);
-        this.gl.uniformMatrix4fv(this.projectionMatrixLocation, false, this.camera.getProjectionMatrix());
-        this.gl.uniformMatrix4fv(this.viewMatrixLocation, false, this.camera.getViewMatrix());
+        this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
 
-        const worldEntities = this.layers.getEntitiesInLayer('world');
-        if (worldEntities) {
-            worldEntities.forEach(entity => {
-                const modelMatrix = mat4.identity();
-                this.gl.uniformMatrix4fv(this.modelMatrixLocation, false, modelMatrix);
-                this.gl.uniform4fv(this.colorLocation, [1, 0, 0, 1]);
+        if (this.battleStageManager) {
+            this.battleStageManager.render(deltaTime);
+        }
 
-                const positionBuffer = this.gl.createBuffer();
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, positionBuffer);
-                const positions = [-0.5, 0.5, -0.5, -0.5, 0.5, 0.5, 0.5, -0.5];
-                this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(positions), this.gl.STATIC_DRAW);
-                this.gl.vertexAttribPointer(this.positionAttributeLocation, 2, this.gl.FLOAT, false, 0, 0);
-                this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
-                this.gl.deleteBuffer(positionBuffer);
+        if (this.battleGridManager) {
+            this.battleGridManager.render(deltaTime);
+        }
+
+        const entityShader = this.shaderPrograms.colorShader;
+        this.useProgram(entityShader.program);
+        this.gl.uniformMatrix4fv(entityShader.uniformLocations['u_projectionMatrix'], false, this.camera.getProjectionMatrix());
+        this.gl.uniformMatrix4fv(entityShader.uniformLocations['u_viewMatrix'], false, this.camera.getViewMatrix());
+
+        const entities = this.layers.getEntitiesInLayer('entities');
+        if (entities) {
+            entities.forEach(entity => {
+                if (entity.render) {
+                    this.drawColorRect(this.gl,
+                        entity.x || 0, entity.y || 0,
+                        entity.width || 50, entity.height || 50,
+                        entity.color || [1, 1, 0, 1],
+                        this.camera);
+                }
             });
         }
 
         this.ui.render(this.gl, deltaTime);
+
         this.res.endFrame();
 
         this.panels.render(deltaTime);
     }
 }
-


### PR DESCRIPTION
## Summary
- add GridEngine for drawing grids
- add battle managers for stage, grids, and logs
- extend Renderer with texture rendering and manager hooks
- update main setup to initialize new systems
- enhance GameLoop to update extra managers
- load background assets in index

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68746a13fec083279c8e0dddd6644dc9