### PR TITLE
Add test runner and example unit test

### DIFF
--- a/js/measurementEngine.js
+++ b/js/measurementEngine.js
@@ -53,7 +53,9 @@ class MeasurementEngine {
         this.scaleY = this.resolutionEngine.canvas.height / this.internalResolution.height;
 
         // 캔버스 크기가 변경될 때마다 스케일링 비율을 업데이트하도록 리스너 추가
-        window.addEventListener('resize', this._updateScaleFactors.bind(this));
+        if (typeof window !== 'undefined') {
+            window.addEventListener('resize', this._updateScaleFactors.bind(this));
+        }
     }
 
     // 캔버스 크기 변경 시 스케일링 비율 업데이트
@@ -240,3 +242,8 @@ class MeasurementEngine {
 //     requestAnimationFrame(gameLoop);
 // }
 */
+
+// Export for Node.js environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = MeasurementEngine;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "Turn-based auto battle RPG prototype",
   "scripts": {
-    "start": "lite-server"
+    "start": "lite-server",
+    "test": "node --test"
   },
   "devDependencies": {
     "lite-server": "^2.6.1"

--- a/test/measurementEngine.test.js
+++ b/test/measurementEngine.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('assert');
+const MeasurementEngine = require('../js/measurementEngine.js');
+
+class StubResolutionEngine {
+  constructor() {
+    this.canvas = { width: 960, height: 540 };
+  }
+  getInternalResolution() {
+    return { width: 1920, height: 1080 };
+  }
+}
+
+test('MeasurementEngine scaling functions convert values based on canvas size', () => {
+  const measure = new MeasurementEngine(new StubResolutionEngine());
+  assert.strictEqual(measure.getPixelX(1920), 960);
+  assert.strictEqual(measure.getPixelY(1080), 540);
+});


### PR DESCRIPTION
## Summary
- support running MeasurementEngine without `window` for Node-based tests
- export `MeasurementEngine` for use in Node
- add `npm test` script and a basic unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68746c2f01208327a4459cb9b9d67db7