### PR TITLE
Implement panel resize & renderer utilities

### DIFF
--- a/js/debug/inputTrackingDebugManager.js
+++ b/js/debug/inputTrackingDebugManager.js
@@ -15,7 +15,7 @@ class InputTrackingDebugManager {
     // 클릭 이벤트 핸들러
     handleMouseClick(event) {
         if (this.isEnabled) {
-            const rect = event.target.getBoundingClientRect();
+            const rect = this.inputManager.canvas.getBoundingClientRect();
             const x = event.clientX - rect.left;
             const y = event.clientY - rect.top;
             this.lastClickCoords = { x: x, y: y };

--- a/js/debugManager.js
+++ b/js/debugManager.js
@@ -41,7 +41,9 @@ class DebugManager {
             touchPos: 'N/A',
             gameTime: '0s',
             // 추가적인 디버그 정보 (예: 특정 오브젝트 위치, 상태 등)
-            custom: {}
+            custom: {},
+            // 일반 메시지 표시용 배열
+            messages: []
         };
 
         console.log("DebugManager initialized.");
@@ -99,6 +101,13 @@ class DebugManager {
             hudContent += `${key}: ${this.debugInfo.custom[key]}<br>`;
         }
 
+        if (this.debugInfo.messages.length > 0) {
+            hudContent += `--- Messages ---<br>`;
+            this.debugInfo.messages.slice(-5).forEach(msg => {
+                hudContent += `${msg}<br>`;
+            });
+        }
+
         this.debugDiv.innerHTML = hudContent;
     }
 
@@ -108,10 +117,20 @@ class DebugManager {
         this.debugInfo.custom[key] = value;
     }
 
+    // 새로 추가된 메서드: 일반 디버그 메시지 추가
+    addDebugMessage(message) {
+        if (!this.isEnabled) return;
+        this.debugInfo.messages.push(message);
+        if (this.debugInfo.messages.length > 10) {
+            this.debugInfo.messages.shift();
+        }
+    }
+
     // 디버거 활성화/비활성화
     toggleEnabled() {
         this.isEnabled = !this.isEnabled;
         this.debugDiv.style.display = this.isEnabled ? 'block' : 'none';
         console.log(`DebugManager ${this.isEnabled ? 'enabled' : 'disabled'}.`);
+        this.addDebugMessage(`DebugManager: ${this.isEnabled ? 'ON' : 'OFF'}`);
     }
 }

--- a/js/engines/sceneEngine.js
+++ b/js/engines/sceneEngine.js
@@ -1,11 +1,12 @@
 // js/engines/sceneEngine.js
 class SceneEngine {
-    constructor(renderer, uiEngine, panelEngine, battleLogEngine, cameraEngine) {
+    constructor(renderer, uiEngine, panelEngine, battleLogEngine, cameraEngine, resolutionEngine) {
         this.renderer = renderer;
         this.uiEngine = uiEngine;
         this.panelEngine = panelEngine;
         this.battleLogEngine = battleLogEngine;
         this.cameraEngine = cameraEngine;
+        this.resolutionEngine = resolutionEngine;
         this.scenes = {}; // 씬들을 저장할 객체
         this.currentScene = null;
         console.log("SceneEngine initialized.");
@@ -49,8 +50,14 @@ class SceneEngine {
 
     // 현재 씬의 그리기 메서드 호출
     draw(renderer) {
+        this.resolutionEngine.beginFrame();
+        this.renderer.gl.viewport(0, 0, this.renderer.gl.drawingBufferWidth, this.renderer.gl.drawingBufferHeight);
+
         if (this.currentScene && this.scenes[this.currentScene]) {
             this.scenes[this.currentScene].draw(renderer);
         }
+
+        this.panelEngine.render(null);
+        this.resolutionEngine.endFrame();
     }
 }

--- a/js/gameLoop.js
+++ b/js/gameLoop.js
@@ -13,6 +13,7 @@ class GameLoop {
         this.delayEngine = delayEngine;
         this.lastTime = 0;
         this.isRunning = false;
+        this.animationFrameId = null; // Store animation frame ID for cancellation
         this.customCallback = null;
 
         console.log("GameLoop initialized.");
@@ -23,13 +24,18 @@ class GameLoop {
         if (this.isRunning) return;
         this.isRunning = true;
         this.lastTime = performance.now(); // 초기 시간 설정
-        requestAnimationFrame(this.loop.bind(this));
+        this.animationFrameId = requestAnimationFrame(this.loop.bind(this));
         console.log("GameLoop started.");
     }
 
     // 게임 루프 정지
     stop() {
+        if (!this.isRunning) return;
         this.isRunning = false;
+        if (this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = null;
+        }
         console.log("GameLoop stopped.");
     }
 
@@ -58,6 +64,6 @@ class GameLoop {
         }
 
         // 다음 프레임 요청
-        requestAnimationFrame(this.loop.bind(this));
+        this.animationFrameId = requestAnimationFrame(this.loop.bind(this));
     }
 }

--- a/js/inputManager.js
+++ b/js/inputManager.js
@@ -20,7 +20,6 @@ class InputManager {
         this.canvas.addEventListener('mousemove', this._onMouseMove.bind(this));
         this.canvas.addEventListener('mousedown', this._onMouseDown.bind(this));
         this.canvas.addEventListener('mouseup', this._onMouseUp.bind(this));
-        this.canvas.addEventListener('click', this._onClick.bind(this));
         this.canvas.addEventListener('contextmenu', this._onContextMenu.bind(this)); // 우클릭 메뉴 방지
 
         // 터치 이벤트 리스너 (모바일 기기용)
@@ -53,16 +52,8 @@ class InputManager {
 
     _onMouseUp(event) {
         this.mouse.buttons.delete(event.button);
-    }
-
-    _onClick(event) {
-        for (const listener of this.clickListeners) {
-            try {
-                listener(event);
-            } catch (e) {
-                console.error('InputManager click listener error:', e);
-            }
-        }
+        // 마우스 버튼이 올라갈 때 클릭 리스너 호출
+        this.clickListeners.forEach(listener => listener(event));
     }
 
     _onContextMenu(event) {

--- a/js/main.js
+++ b/js/main.js
@@ -75,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mercenaryPanelGridManager = new MercenaryPanelGridManager(gridEngine, panelEngine, measurementEngine);
 
     // ✨ 새로운 엔진들 초기화
-    const sceneEngine = new SceneEngine(renderer, uiEngine, panelEngine, battleLogEngine, cameraEngine);
+    const sceneEngine = new SceneEngine(renderer, uiEngine, panelEngine, battleLogEngine, cameraEngine, resolutionEngine);
     const territoryEngine = new TerritoryEngine(gameEngine, sceneEngine, uiEngine, battleLogEngine, measurementEngine);
 
     // ✨ 인풋 트래킹 디버그 매니저 초기화

--- a/js/managers/cameraEngine.js
+++ b/js/managers/cameraEngine.js
@@ -115,6 +115,16 @@ class CameraEngine {
         const worldY = internalY / this.zoom + this.position.y;
         return { x: worldX, y: worldY };
     }
+
+    // 새로 추가된 메서드: 카메라 초기화
+    resetCamera() {
+        this.position = { x: 0, y: 0 };
+        this.zoom = 1.0;
+        this.rotation = 0;
+        this.viewMatrix = this.createViewMatrix();
+        this.updateProjectionMatrix();
+        console.log("CameraEngine: Camera reset to default.");
+    }
 }
 
 

--- a/js/managers/panelEngine.js
+++ b/js/managers/panelEngine.js
@@ -67,6 +67,14 @@ class PanelEngine {
         console.log(`Panel '${panel.id}' resized to ${measuredWidth}x${measuredHeight}`);
     }
 
+    // 새로 추가된 메서드: 등록된 모든 패널의 크기와 스타일을 다시 적용
+    resizeAllPanels() {
+        this.panels.forEach(panel => {
+            this._applyPanelStyle(panel);
+        });
+        console.log('PanelEngine: All panels resized.');
+    }
+
     getPanel(panelId) {
         return this.panels.get(panelId);
     }

--- a/js/managers/uiEngine.js
+++ b/js/managers/uiEngine.js
@@ -24,6 +24,8 @@ class UIEngine {
                 fontSize: options.fontSize || this.measure.getFontSizeMedium(),
                 color: options.color || '#FFFFFF',
                 isVisible: options.isVisible !== undefined ? options.isVisible : true,
+                textAlign: options.textAlign || 'left',
+                textBaseline: options.textBaseline || 'top',
                 ...options
             },
             onClick: onClick
@@ -31,6 +33,19 @@ class UIEngine {
         this.uiElements.set(id, element);
         console.log(`UI Element '${id}' (${type}) registered.`);
         return element;
+    }
+
+    // 새로 추가된 메서드: UI 요소 등록 해제
+    unregisterUIElement(id) {
+        if (this.uiElements.has(id)) {
+            const element = this.uiElements.get(id);
+            element.options.isVisible = false;
+            this.uiElements.delete(id);
+            console.log(`UI Element '${id}' unregistered.`);
+            return true;
+        }
+        console.warn(`UI Element '${id}' not found for unregistration.`);
+        return false;
     }
 
     getUIElement(id) {
@@ -57,18 +72,21 @@ class UIEngine {
 
     update(deltaTime) {
         this.uiElements.forEach(element => {
-            if (element.options.isVisible) {
-                if (element.onClick) {
-                    const mousePos = this.input.getMousePosition();
-                    const isLeftButtonPressed = this.input.isMouseButtonPressed(0);
-                    const pixelX = this.measure.getPixelX(element.options.x);
-                    const pixelY = this.measure.getPixelY(element.options.y);
-                    const pixelWidth = this.measure.getPixelX(element.options.width);
-                    const pixelHeight = this.measure.getPixelY(element.options.height);
-                    const isHovering = mousePos.x >= pixelX && mousePos.x <= pixelX + pixelWidth && mousePos.y >= pixelY && mousePos.y <= pixelY + pixelHeight;
-                    if (isHovering && isLeftButtonPressed) {
-                        // element.onClick();
-                    }
+            if (!element.options.isVisible) return;
+
+            if (element.onClick && element.type === 'button') {
+                const mousePos = this.input.getMousePosition();
+                const isLeftButtonPressed = this.input.isMouseButtonPressed(0);
+                const pixelX = this.measure.getPixelX(element.options.x);
+                const pixelY = this.measure.getPixelY(element.options.y);
+                const pixelWidth = this.measure.getPixelX(element.options.width);
+                const pixelHeight = this.measure.getPixelY(element.options.height);
+
+                const isHovering = mousePos.x >= pixelX && mousePos.x <= pixelX + pixelWidth &&
+                                   mousePos.y >= pixelY && mousePos.y <= pixelY + pixelHeight;
+
+                if (isHovering && isLeftButtonPressed) {
+                    element.onClick();
                 }
             }
         });
@@ -76,14 +94,51 @@ class UIEngine {
 
     render(gl, deltaTime) {
         this.uiElements.forEach(element => {
-            if (element.options.isVisible) {
-                const pixelX = this.measure.getPixelX(element.options.x);
-                const pixelY = this.measure.getPixelY(element.options.y);
-                const pixelWidth = this.measure.getPixelX(element.options.width);
-                const pixelHeight = this.measure.getPixelY(element.options.height);
-                // Placeholder for actual rendering logic
+            if (!element.options.isVisible) return;
+
+            const pixelX = this.measure.getPixelX(element.options.x);
+            const pixelY = this.measure.getPixelY(element.options.y);
+            const pixelWidth = this.measure.getPixelX(element.options.width);
+            const pixelHeight = this.measure.getPixelY(element.options.height);
+
+            if (element.type === 'button') {
+                gl.renderer.drawColorRect(gl, pixelX, pixelY, pixelWidth, pixelHeight,
+                    this._hexToRgbA(element.options.color), null);
+            } else if (element.type === 'text') {
+                const ctx = gl.canvas.getContext('2d');
+                if (ctx) {
+                    ctx.font = `${element.options.fontSize}px Arial`;
+                    ctx.fillStyle = element.options.color;
+                    ctx.textAlign = element.options.textAlign;
+                    ctx.textBaseline = element.options.textBaseline;
+
+                    let textX = pixelX;
+                    let textY = pixelY;
+
+                    if (element.options.textAlign === 'center') textX += pixelWidth / 2;
+                    else if (element.options.textAlign === 'right') textX += pixelWidth;
+
+                    if (element.options.textBaseline === 'middle') textY += pixelHeight / 2;
+                    else if (element.options.textBaseline === 'bottom') textY += pixelHeight;
+
+                    ctx.fillText(element.options.text, textX, textY);
+                }
             }
         });
+    }
+
+    // 헬퍼 함수: 헥스 색상을 RGBA 배열로 변환
+    _hexToRgbA(hex) {
+        let c;
+        if(/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)){
+            c= hex.substring(1).split('');
+            if(c.length===3){
+                c= [c[0], c[0], c[1], c[1], c[2], c[2]];
+            }
+            c= '0x'+c.join('');
+            return [(c>>16)&255, (c>>8)&255, c&255, 1].map(x=>x/255);
+        }
+        return [1,1,1,1];
     }
 }
 

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -347,11 +347,20 @@ class Renderer {
         return matrix;
     }
 
+    // 새로 추가된 메서드: 캔버스 배경색 설정
+    setClearColor(r, g, b, a) {
+        this.gl.clearColor(r, g, b, a);
+    }
+
+    // 새로 추가된 메서드: 캔버스 지우기
+    clear() {
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+    }
+
 
     // 게임 상태를 화면에 그리기
     render(gameState, deltaTime) {
-        // 메인 게임 캔버스 렌더링 시작
-        this.res.beginFrame();
+        // 메인 게임 캔버스 렌더링 시작은 SceneEngine이 담당
         this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT); // 매 프레임 버퍼 지우기
 
@@ -416,7 +425,7 @@ class Renderer {
         }
 
 
-        this.res.endFrame(); // 메인 게임 캔버스 렌더링 종료
+        // 메인 게임 캔버스 렌더링 종료는 SceneEngine이 담당
 
         // 각 오버레이 패널 캔버스 렌더링
         // PanelEngine의 render 메서드가 각 패널의 자체 컨텍스트에 그리는 것을 관리합니다.

--- a/test/renderer.test.js
+++ b/test/renderer.test.js
@@ -468,9 +468,16 @@ class Renderer {
         return matrix;
     }
 
+    setClearColor(r, g, b, a) {
+        this.gl.clearColor(r, g, b, a);
+    }
+
+    clear() {
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+    }
+
 
     render(gameState, deltaTime) {
-        this.res.beginFrame();
         this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
@@ -516,8 +523,6 @@ class Renderer {
              this.drawColorRect(this.gl, px, py, pw, ph, [0.1, 0.5, 0.8, 1.0], null);
         }
 
-
-        this.res.endFrame();
 
         this.panels.render(deltaTime);
     }
@@ -718,7 +723,7 @@ test('Renderer Tests', async (t) => {
 
         renderer.render(gameState, deltaTime);
 
-        assert.strictEqual(mockResEngine.beginFrame.mock.callCount(), 1, 'ResolutionEngine.beginFrame called');
+        assert.strictEqual(mockResEngine.beginFrame.mock.callCount(), 0, 'ResolutionEngine.beginFrame should not be called');
         assert.strictEqual(mockGL.viewport.mock.callCount(), 1, 'GL viewport set');
         assert.strictEqual(mockGL.clear.mock.callCount(), 1, 'GL clear called');
 
@@ -738,7 +743,7 @@ test('Renderer Tests', async (t) => {
         assert.strictEqual(mockPanelEngine.render.mock.callCount(), 1, 'PanelEngine.render called');
         assert.strictEqual(mockPanelEngine.render.mock.calls[0].arguments[0], deltaTime, 'PanelEngine.render receives deltaTime');
 
-        assert.strictEqual(mockResEngine.endFrame.mock.callCount(), 1, 'ResolutionEngine.endFrame called');
+        assert.strictEqual(mockResEngine.endFrame.mock.callCount(), 0, 'ResolutionEngine.endFrame should not be called');
     });
 });
 


### PR DESCRIPTION
## Summary
- manage panel resizing across scenes
- expose clear color controls in Renderer and remove frame control from Renderer.render
- show debug messages in DebugManager and track input clicks relative to canvas
- extend UIEngine for element removal and basic text rendering
- manage scene rendering through SceneEngine with begin/end frame
- add camera reset logic and improved game loop frame handling
- adjust tests for updated behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68749772dc4483278a940fe093830d58