### PR TITLE
Expose UIEngine via getters

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -109,4 +109,8 @@ export class GameEngine {
     getRenderEngine() { return this.renderEngine; }
     getBattleEngine() { return this.battleEngine; }
     getUnitStatManager() { return this.unitStatManager; }
+
+    getUIEngine() {
+        return this.renderEngine.getUIEngine();
+    }
 }

--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -45,4 +45,5 @@ export class RenderEngine {
 
     getAnimationManager() { return this.animationManager; }
     getLayerEngine() { return this.layerEngine; }
+    getUIEngine() { return this.uiEngine; }
 }


### PR DESCRIPTION
## Summary
- expose RenderEngine's UIEngine instance with a new getter
- provide GameEngine helper to access the UIEngine through RenderEngine

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878998fd6dc8327a88266961c591018