### PR TITLE
feat: inject battle simulator into combat engine

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -98,6 +98,8 @@ export class BattleSimulatorEngine {
 
         // ✨ AspirationEngine에 battleSimulator 참조 설정
         aspirationEngine.setBattleSimulator(this);
+        // ✨ CombatCalculationEngine에 battleSimulator 참조 설정
+        combatCalculationEngine.setBattleSimulator(this);
 
         this.turnQueue = [];
         this.currentTurnIndex = 0;
@@ -149,7 +151,7 @@ export class BattleSimulatorEngine {
         sharedResourceEngine.initialize('ally');
         sharedResourceEngine.initialize('enemy');
         statusEffectManager.setBattleSimulator(this);
-        combatCalculationEngine.battleSimulator = this;
+        combatCalculationEngine.setBattleSimulator(this);
         // ✨ 전투 시작 시 음양 엔진을 초기화합니다.
         yinYangEngine.initializeUnits([...allies, ...enemies]);
 
@@ -420,7 +422,7 @@ export const battleSimulatorEngine = {
         // 컴뱃 계산 엔진과 상태 효과 매니저가 참조할 전투 컨텍스트
         const battleContext = { turnQueue: allUnits };
         statusEffectManager.setBattleSimulator(battleContext);
-        combatCalculationEngine.battleSimulator = battleContext;
+        combatCalculationEngine.setBattleSimulator(battleContext);
 
         const basicAttack = {
             id: 'basicAttack',

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -33,12 +33,19 @@ import { statusEffects } from '../data/status-effects.js';
  * 실제 전투 데미지 계산을 담당하는 엔진
  */
 class CombatCalculationEngine {
-    // ✨ --- [핵심 버그 수정] 생성자와 name 속성 추가 --- ✨
+    // ✨ --- [핵심 버그 수정] 생성자와 battleSimulator 참조 추가 --- ✨
     constructor() {
         this.name = 'CombatCalculationEngine';
         this.battleSimulator = null;
-        // 다른 엔진들과의 일관성을 위해 debugLogEngine에 등록할 수도 있습니다.
         debugLogEngine.register(this);
+    }
+
+    /**
+     * BattleSimulatorEngine의 참조를 이 엔진에 주입합니다.
+     * @param {object} simulator - BattleSimulatorEngine 인스턴스
+     */
+    setBattleSimulator(simulator) {
+        this.battleSimulator = simulator;
     }
     // ✨ --- 수정 완료 --- ✨
 


### PR DESCRIPTION
## Summary
- add constructor and setter to CombatCalculationEngine to hold battleSimulator reference
- wire BattleSimulatorEngine to pass itself to CombatCalculationEngine

## Testing
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b63df6a948327ba20ba4286a5fc93