### PR TITLE
Add basic units and world map unit setup

### DIFF
--- a/src/game/actors/Unit.js
+++ b/src/game/actors/Unit.js
@@ -1,0 +1,25 @@
+import { GameObjects } from "phaser";
+
+export class Unit {
+  constructor(scene, gridX, gridY, data, faction) {
+    this.scene = scene;
+    this.gridX = gridX;
+    this.gridY = gridY;
+    this.data = data;
+    this.faction = faction;
+
+    // 기본 스프라이트 생성
+    this.sprite = scene.add.sprite(0, 0, data.sprite);
+    scene.add.existing(this.sprite);
+
+    // 초기 위치 설정
+    this.move(gridX, gridY);
+  }
+
+  move(gridX, gridY) {
+    this.gridX = gridX;
+    this.gridY = gridY;
+    const tileSize = 50; // Grid와 동일한 타일 크기 가정
+    this.sprite.setPosition(gridX * tileSize, gridY * tileSize);
+  }
+}

--- a/src/game/data/units.js
+++ b/src/game/data/units.js
@@ -1,0 +1,48 @@
+// src/game/data/units.js
+
+export const units = {
+  player: {
+    name: "아군 지휘관",
+    hp: 100,
+    maxHp: 100,
+    attack: 10,
+    defense: 5,
+    speed: 50, // 속도 스탯 추가
+    weight: 10, // 무게 (기존 턴 순서용)
+    sprite: "istp",
+    skills: [],
+  },
+  enemyCommander: {
+    name: "적 지휘관",
+    hp: 100,
+    maxHp: 100,
+    attack: 10,
+    defense: 5,
+    speed: 50,
+    weight: 10,
+    sprite: "infp", // 적절한 스프라이트 이름으로 변경 필요
+    skills: [],
+  },
+  alliedMercenary: {
+    name: "아군 용병",
+    hp: 80,
+    maxHp: 80,
+    attack: 15,
+    defense: 3,
+    speed: 60,
+    weight: 8,
+    sprite: "warrior", // 적절한 스프라이트 이름으로 변경 필요
+    skills: [],
+  },
+  enemyMercenary: {
+    name: "적군 용병",
+    hp: 80,
+    maxHp: 80,
+    attack: 15,
+    defense: 3,
+    speed: 40,
+    weight: 12,
+    sprite: "warrior", // 적절한 스프라이트 이름으로 변경 필요
+    skills: [],
+  },
+};

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,45 +1,90 @@
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { WorldMapEngine } from '../utils/WorldMapEngine.js';
-import { LeaderEngine } from '../utils/LeaderEngine.js';
-import { WorldMapTurnEngine } from '../utils/WorldMapTurnEngine.js';
-import { CameraControlEngine } from '../utils/CameraControlEngine.js';
+// src/game/scenes/WorldMapScene.js
+
+import { Scene } from "phaser";
+import { Grid } from "../utils/Grid";
+import { Unit } from "../actors/Unit";
+import { units as unitData } from "../data/units";
 
 export class WorldMapScene extends Scene {
-    constructor() {
-        super('WorldMapScene');
-    }
+  constructor() {
+    super("WorldMapScene");
+  }
 
-    create() {
-        // 다른 DOM 컨테이너 숨기기
-        const territoryContainer = document.getElementById('territory-container');
-        if (territoryContainer) {
-            territoryContainer.style.display = 'none';
-        }
+  create() {
+    this.grid = new Grid(this, 30, 20, 50);
+    this.units = []; // 모든 유닛을 관리할 배열
 
-        // 1. 월드맵 엔진을 생성하고 맵을 만듭니다.
-        const mapEngine = new WorldMapEngine(this);
-        mapEngine.create();
+    // 아군 지휘관 생성
+    const player = new Unit(this, 5, 10, unitData.player, "player");
+    this.playerUnit = player; // 플레이어 유닛은 따로 관리하여 조작
+    this.units.push(player);
+    this.grid.add(player.sprite, 5, 10);
 
-        // 2. 리더 엔진을 생성하고 플레이어 캐릭터를 만듭니다.
-        const leaderEngine = new LeaderEngine(this, mapEngine);
-        leaderEngine.create();
-        
-        // 3. 턴 엔진을 생성하여 키보드 입력을 처리합니다.
-        new WorldMapTurnEngine(this, leaderEngine);
+    // 적군 지휘관 생성
+    const enemyCommander = new Unit(
+      this,
+      25,
+      10,
+      unitData.enemyCommander,
+      "enemy"
+    );
+    this.units.push(enemyCommander);
+    this.grid.add(enemyCommander.sprite, 25, 10);
 
-        // 4. 카메라 드래그 및 줌 기능을 활성화합니다.
-        new CameraControlEngine(this);
+    // 용병 생성 (2명씩)
+    const alliedMerc1 = new Unit(
+      this,
+      5,
+      12,
+      unitData.alliedMercenary,
+      "player"
+    );
+    this.units.push(alliedMerc1);
+    this.grid.add(alliedMerc1.sprite, 5, 12);
 
-        // 'T' 키를 누르면 영지 씬으로 돌아가는 기능을 추가합니다.
-        this.input.keyboard.on('keydown-T', () => {
-            this.scene.start('TerritoryScene');
-        });
-        
-        // 씬이 종료될 때 DOM 요소를 정리하도록 이벤트를 설정합니다.
-        this.events.on('shutdown', () => {
-            if (territoryContainer) {
-                territoryContainer.style.display = 'block';
-            }
-        });
-    }
+    const alliedMerc2 = new Unit(
+      this,
+      7,
+      12,
+      unitData.alliedMercenary,
+      "player"
+    );
+    this.units.push(alliedMerc2);
+    this.grid.add(alliedMerc2.sprite, 7, 12);
+
+    const enemyMerc1 = new Unit(
+      this,
+      23,
+      12,
+      unitData.enemyMercenary,
+      "enemy"
+    );
+    this.units.push(enemyMerc1);
+    this.grid.add(enemyMerc1.sprite, 23, 12);
+
+    const enemyMerc2 = new Unit(
+      this,
+      25,
+      12,
+      unitData.enemyMercenary,
+      "enemy"
+    );
+    this.units.push(enemyMerc2);
+    this.grid.add(enemyMerc2.sprite, 25, 12);
+
+    // 플레이어 이동 로직
+    this.input.on("pointerdown", (pointer) => {
+      const { gridX, gridY } = this.grid.getGridPosition(pointer.x, pointer.y);
+      this.playerUnit.move(gridX, gridY);
+
+      // STEP 2에서 구현할 함수 호출 (지금은 빈 함수)
+      this.runWeGoTurn();
+    });
+  }
+
+  // STEP 2에서 구현할 We-go 턴 실행 함수
+  runWeGoTurn() {
+    console.log("We-go turn triggered! (아직 기능 없음)");
+    // 이 안에 행동력 기반의 전투 로직이 들어갈 예정입니다.
+  }
 }

--- a/src/game/utils/Grid.js
+++ b/src/game/utils/Grid.js
@@ -1,0 +1,19 @@
+export class Grid {
+  constructor(scene, columns, rows, tileSize) {
+    this.scene = scene;
+    this.columns = columns;
+    this.rows = rows;
+    this.tileSize = tileSize;
+  }
+
+  add(sprite, gridX, gridY) {
+    sprite.setPosition(gridX * this.tileSize, gridY * this.tileSize);
+  }
+
+  getGridPosition(x, y) {
+    return {
+      gridX: Math.floor(x / this.tileSize),
+      gridY: Math.floor(y / this.tileSize),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Define player and mercenary unit stats
- Introduce simple Unit and Grid helpers
- Populate world map scene with commanders and mercenaries

## Testing
- `npm run build`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c675639488327b6c38c912f8a26ba