### PR TITLE
fix: use CDN phaser imports to prevent module resolution error

### DIFF
--- a/src/game/actors/Unit.js
+++ b/src/game/actors/Unit.js
@@ -1,5 +1,3 @@
-import { GameObjects } from "phaser";
-
 export class Unit {
   constructor(scene, gridX, gridY, data, faction) {
     this.scene = scene;

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,6 +1,7 @@
 // src/game/scenes/WorldMapScene.js
 
-import { Scene } from "phaser";
+// Vite 없이 실행할 수 있도록 phaser ESM을 직접 참조합니다.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { Grid } from "../utils/Grid";
 import { Unit } from "../actors/Unit";
 import { units as unitData } from "../data/units";


### PR DESCRIPTION
## Summary
- import Phaser Scene from CDN in WorldMapScene to work without bundler
- remove unused Phaser import in Unit actor

## Testing
- `npm test` (fails: Missing script: "test")
- `python3 -m http.server 8000 &` followed by `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c69a30578832786bcae24cae81ce6