### PR TITLE
fix: load Phaser from CDN in WorldMapScene

### DIFF
--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,6 +1,6 @@
 // src/game/scenes/WorldMapScene.js
 
-import { Scene } from "phaser";
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 // --- 수정된 부분 ---
 import { Grid } from "../utils/Grid.js";
 import { Unit } from "../actors/Unit.js";


### PR DESCRIPTION
## Summary
- fix module resolution error by importing Phaser Scene from CDN in WorldMapScene

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c6da3a0448327832fda19a520ce71