### PR TITLE
feat: add action planning system and AP manager

### DIFF
--- a/src/game/actors/Unit.js
+++ b/src/game/actors/Unit.js
@@ -10,7 +10,6 @@ export class Unit {
     this.gridX = gridX;
     this.gridY = gridY;
     
-    // 기본 데이터와 병합
     const baseMercData = mercenaryData[unitData.id] || {};
     Object.assign(this, { ...baseMercData, ...unitData });
 
@@ -19,22 +18,18 @@ export class Unit {
     this.sprite = scene.add.sprite(0, 0, this.sprite);
     this.finalStats = statEngine.calculateStats(this, this.baseStats || unitData);
     this.currentHp = this.finalStats.hp;
+    this.currentAP = 0;
 
-    // --- 🔹 STEP 3 추가된 부분 🔹 ---
-    this.currentAP = 0; // 행동력(Action Power) 변수 추가 및 초기화
+    // --- 🔹 STEP 5 추가된 부분 🔹 ---
+    /** @type {any} 행동 계획을 저장하는 변수 (예: {type: 'attack', target: Unit}) */
+    this.plannedAction = null; 
     // ------------------------------------
   }
 
-  // --- 🔹 STEP 3 추가된 부분 🔹 ---
-  /**
-   * 유닛의 속도에 비례하여 행동력(AP)을 축적합니다.
-   * 이 값은 나중에 소수점 계산의 정확도를 위해 100으로 나눕니다.
-   */
   accumulateAP() {
     this.currentAP += this.finalStats.speed / 100;
   }
-  // ------------------------------------
-
+  
   move(gridX, gridY) {
     this.gridX = gridX;
     this.gridY = gridY;

--- a/src/game/components/ActionPowerManager.js
+++ b/src/game/components/ActionPowerManager.js
@@ -1,0 +1,49 @@
+// src/game/components/ActionPowerManager.js
+
+export class ActionPowerManager {
+  /**
+   * @param {Array<Unit>} units - 전투에 참여하는 모든 유닛의 배열
+   */
+  constructor(units) {
+    this.units = units;
+  }
+
+  /**
+   * 매 턴 시작 시 모든 유닛의 행동력을 축적시킵니다.
+   */
+  accumulateAllAP() {
+    console.log("--- AP 충전 ---");
+    this.units.forEach(unit => {
+      unit.accumulateAP();
+      console.log(`${unit.name}: ${unit.currentAP.toFixed(2)} AP`);
+    });
+  }
+
+  /**
+   * 행동할 유닛들의 우선순위 목록을 반환합니다.
+   * @returns {Array<Unit>} AP가 높은 순서로 정렬된 유닛 배열
+   */
+  getActionPriorityList() {
+    // 행동력이 1 이상인 유닛들만 필터링하여, AP가 높은 순으로 정렬합니다.
+    const readyUnits = this.units.filter(unit => unit.currentAP >= 1);
+    
+    readyUnits.sort((a, b) => b.currentAP - a.currentAP);
+
+    console.log("--- 행동 순서 결정 ---");
+    readyUnits.forEach((unit, index) => {
+      console.log(`${index + 1}순위: ${unit.name} (${unit.currentAP.toFixed(2)} AP)`);
+    });
+
+    return readyUnits;
+  }
+
+  /**
+   * 유닛의 행동이 끝나면 소모된 AP를 차감합니다.
+   * @param {Unit} unit - 행동을 마친 유닛
+   * @param {number} cost - 소모된 AP (기본값 1)
+   */
+  spendAP(unit, cost = 1) {
+    unit.currentAP -= cost;
+    console.log(`${unit.name} 행동 완료. 남은 AP: ${unit.currentAP.toFixed(2)}`);
+  }
+}

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,11 +1,9 @@
 // src/game/scenes/WorldMapScene.js
 
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-// --- 수정된 부분 ---
 import { Grid } from "../utils/Grid.js";
 import { Unit } from "../actors/Unit.js";
 import { units as unitData } from "../data/units.js";
-// --------------------
 
 export class WorldMapScene extends Scene {
   constructor() {
@@ -14,50 +12,85 @@ export class WorldMapScene extends Scene {
 
   create() {
     this.grid = new Grid(this, 30, 20, 50);
-    this.units = []; // 모든 유닛을 관리할 배열
+    this.units = []; 
 
-    // 아군 지휘관 생성
+    // --- 유닛 생성 코드는 이전과 동일합니다 (생략) ---
     const player = new Unit(this, 5, 10, unitData.player, "player");
-    this.playerUnit = player; // 플레이어 유닛은 따로 관리하여 조작
+    this.playerUnit = player;
     this.units.push(player);
     this.grid.add(player.sprite, 5, 10);
-
-    // 적군 지휘관 생성
     const enemyCommander = new Unit(this, 25, 10, unitData.enemyCommander, "enemy");
     this.units.push(enemyCommander);
     this.grid.add(enemyCommander.sprite, 25, 10);
-
-    // 용병 생성 (2명씩)
     const alliedMerc1 = new Unit(this, 5, 12, unitData.alliedMercenary, "player");
     this.units.push(alliedMerc1);
     this.grid.add(alliedMerc1.sprite, 5, 12);
-
     const alliedMerc2 = new Unit(this, 7, 12, unitData.alliedMercenary, "player");
     this.units.push(alliedMerc2);
     this.grid.add(alliedMerc2.sprite, 7, 12);
-
     const enemyMerc1 = new Unit(this, 23, 12, unitData.enemyMercenary, "enemy");
     this.units.push(enemyMerc1);
     this.grid.add(enemyMerc1.sprite, 23, 12);
-
     const enemyMerc2 = new Unit(this, 25, 12, unitData.enemyMercenary, "enemy");
     this.units.push(enemyMerc2);
     this.grid.add(enemyMerc2.sprite, 25, 12);
+    // ----------------------------------------------------
 
-    // 플레이어 이동 로직
     this.input.on("pointerdown", (pointer) => {
       const { gridX, gridY } = this.grid.getGridPosition(pointer.x, pointer.y);
       this.playerUnit.move(gridX, gridY);
-
-      // STEP 2에서 구현할 함수 호출 (지금은 빈 함수)
       this.runWeGoTurn();
     });
   }
 
-  // STEP 2에서 구현할 We-go 턴 실행 함수
   runWeGoTurn() {
-    console.log("We-go turn triggered! (아직 기능 없음)");
-    // 이 안에 행동력 기반의 전투 로직이 들어갈 예정입니다.
+    console.log("===== We-Go Turn Start! =====");
+    // TODO: 여기에 AP 충전 로직을 넣을 예정
+    this.planAIActions();
+    // TODO: 여기에 행동 실행 로직을 넣을 예정
   }
-}
 
+  // --- 🔹 STEP 5 추가된 함수 🔹 ---
+  /**
+   * 모든 AI 유닛의 행동 계획을 수립합니다.
+   */
+  planAIActions() {
+    console.log("--- AI 계획 단계 ---");
+    // 모든 유닛들을 순회하며
+    this.units.forEach(unit => {
+      // AI 유닛(적군)일 경우에만 계획을 세웁니다.
+      if (unit.faction === 'enemy') {
+        const target = this.findClosestTarget(unit, 'player');
+        if (target) {
+          // 계획을 세웁니다: "저 타겟을 공격하겠다!"
+          unit.plannedAction = { type: 'attack', target: target };
+          console.log(`${unit.name}이(가) ${target.name}을(를) 공격할 계획입니다.`);
+        }
+      }
+    });
+  }
+
+  /**
+   * 특정 유닛에게서 가장 가까운 적을 찾습니다.
+   * @param {Unit} fromUnit - 기준 유닛
+   * @param {string} targetFaction - 찾을 목표의 진영 ('player' or 'enemy')
+   * @returns {Unit | null} 가장 가까운 타겟 유닛
+   */
+  findClosestTarget(fromUnit, targetFaction) {
+    const targets = this.units.filter(u => u.faction === targetFaction && u.currentHp > 0);
+    if (targets.length === 0) return null;
+
+    let closestTarget = null;
+    let minDistance = Infinity;
+
+    targets.forEach(target => {
+      const distance = Phaser.Math.Distance.Between(fromUnit.gridX, fromUnit.gridY, target.gridX, target.gridY);
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestTarget = target;
+      }
+    });
+    return closestTarget;
+  }
+  // ------------------------------------
+}


### PR DESCRIPTION
## Summary
- add ActionPowerManager component to handle AP accumulation and spending
- allow units to store planned actions
- make enemies plan attacks on nearest player unit each turn

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c7383a3d88327b1f32f36f5051aec