### PR TITLE
Add city scene and world map integration

### DIFF
--- a/src/game/data/city.js
+++ b/src/game/data/city.js
@@ -1,0 +1,10 @@
+export const cityData = {
+    'mab-city-1': {
+        id: 'mab-city-1',
+        name: 'Mab City',
+        tileX: 11,
+        tileY: 9,
+        icon: 'mab-city-1-icon',
+        scene: 'CityScene'
+    }
+};

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -20,6 +20,7 @@ import { EquipmentManagementScene } from './EquipmentManagementScene.js';
 import { ArenaScene } from './ArenaScene.js';
 import { ArenaBattleScene } from './ArenaBattleScene.js';
 import { WorldMapScene } from './WorldMapScene.js'; // 월드맵 씬 import 추가
+import { CityScene } from './CityScene.js';
 
 export class Boot extends Scene
 {
@@ -56,6 +57,7 @@ export class Boot extends Scene
         this.scene.add('ArenaScene', ArenaScene);
         this.scene.add('ArenaBattleScene', ArenaBattleScene);
         this.scene.add('WorldMapScene', WorldMapScene); // 월드맵 씬 추가
+        this.scene.add('CityScene', CityScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/CityScene.js
+++ b/src/game/scenes/CityScene.js
@@ -1,0 +1,122 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+export class CityScene extends Scene {
+    constructor() {
+        super('CityScene');
+    }
+
+    create(data) {
+        this.add.image(this.cameras.main.centerX, this.cameras.main.centerY, 'city-1-bg');
+
+        ['territory-container', 'dungeon-container', 'party-container', 'formation-container'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.style.display = 'none';
+            }
+        });
+
+        const cityContainer = document.createElement('div');
+        cityContainer.id = 'city-container';
+        Object.assign(cityContainer.style, {
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            pointerEvents: 'none'
+        });
+
+        const grid = this.createGrid();
+        this.populateGrid(grid);
+
+        cityContainer.appendChild(grid);
+        document.getElementById('app').appendChild(cityContainer);
+
+        const backButton = this.createBackButton();
+        cityContainer.appendChild(backButton);
+
+        this.events.on('shutdown', () => {
+            const existing = document.getElementById('city-container');
+            if (existing) {
+                existing.remove();
+            }
+        });
+    }
+
+    createGrid() {
+        const grid = document.createElement('div');
+        grid.id = 'city-grid';
+        Object.assign(grid.style, {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gridTemplateRows: 'repeat(3, 1fr)',
+            width: '50%',
+            height: '60%',
+            gap: '30px',
+            pointerEvents: 'auto'
+        });
+        return grid;
+    }
+
+    populateGrid(grid) {
+        const icons = [
+            { name: '여관', icon: 'tavern-icon', tooltip: '[여관]' },
+            { name: '스킬샵', icon: 'skills-icon', tooltip: '[스킬샵]' },
+            { name: '장비샵', icon: 'inventory-icon', tooltip: '[장비샵]' }
+        ];
+
+        const positions = [3, 4, 5];
+        icons.forEach((iconData, index) => {
+            const cell = document.createElement('div');
+            cell.style.gridRowStart = `${Math.floor(positions[index] / 3) + 1}`;
+            cell.style.gridColumnStart = `${(positions[index] % 3) + 1}`;
+            cell.style.display = 'flex';
+            cell.style.flexDirection = 'column';
+            cell.style.alignItems = 'center';
+            cell.style.justifyContent = 'center';
+
+            const iconElement = document.createElement('div');
+            iconElement.className = 'building-icon';
+            iconElement.style.backgroundImage = `url(assets/images/territory/${iconData.icon}.png)`;
+            iconElement.style.width = '120px';
+            iconElement.style.height = '120px';
+
+            const label = document.createElement('div');
+            label.innerText = iconData.name;
+            Object.assign(label.style, {
+                textAlign: 'center',
+                color: 'white',
+                marginTop: '10px',
+                fontSize: '20px',
+                textShadow: '1px 1px 2px black'
+            });
+
+            cell.appendChild(iconElement);
+            cell.appendChild(label);
+            grid.appendChild(cell);
+        });
+    }
+
+    createBackButton() {
+        const backButton = document.createElement('div');
+        backButton.id = 'city-back-button';
+        backButton.innerText = '← 월드맵으로';
+        Object.assign(backButton.style, {
+            position: 'absolute',
+            top: '20px',
+            left: '20px',
+            padding: '10px 15px',
+            backgroundColor: 'rgba(0,0,0,0.7)',
+            color: 'white',
+            cursor: 'pointer',
+            borderRadius: '5px'
+        });
+
+        backButton.onclick = () => {
+            this.scene.start('WorldMapScene');
+        };
+
+        return backButton;
+    }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -105,11 +105,13 @@ export class Preloader extends Scene
         this.load.image('dark-knight-ui', 'images/unit/dark-knight-ui.png');
         // --- ▲ [신규] 다크나이트 UI 이미지 로드 ▲ ---
 
-        // 영지 씬에 사용할 배경 이미지를 로드합니다.
+        // 영지 및 도시 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
+        this.load.image('city-1-bg', 'images/territory/city-1.png');
 
         // 여관 아이콘 이미지를 로드합니다.
         this.load.image('tavern-icon', 'images/territory/tavern-icon.png');
+        this.load.image('inventory-icon', 'images/territory/inventory-icon.png');
 
         // --- 추가된 애셋들 ---
         this.load.image('tavern-scene', 'images/territory/tavern-scene.png');
@@ -121,6 +123,9 @@ export class Preloader extends Scene
         // --- ▼ [신규] 월드맵 애셋 로드 ▼ ---
         // 리더 스프라이트
         this.load.image('leader-infp', 'images/leaders/infp.png');
+
+        // 월드맵 도시 아이콘
+        this.load.image('mab-city-1-icon', 'images/world-mab/mab-city-1.png');
 
         // 월드맵 타일 (15개)
         for (let i = 1; i <= 15; i++) {

--- a/src/game/utils/CityEngine.js
+++ b/src/game/utils/CityEngine.js
@@ -1,0 +1,30 @@
+import { cityData } from '../data/city.js';
+
+/**
+ * 월드맵의 도시 정보를 관리하는 엔진
+ */
+class CityEngine {
+    constructor() {
+        this.cities = [];
+        this.initializeCities();
+    }
+
+    /**
+     * 데이터 파일로부터 도시 정보를 초기화합니다.
+     */
+    initializeCities() {
+        for (const cityId in cityData) {
+            this.cities.push(cityData[cityId]);
+        }
+    }
+
+    /**
+     * 모든 도시의 목록을 반환합니다.
+     * @returns {Array<object>}
+     */
+    getCities() {
+        return this.cities;
+    }
+}
+
+export const cityEngine = new CityEngine();

--- a/src/game/utils/LeaderEngine.js
+++ b/src/game/utils/LeaderEngine.js
@@ -1,4 +1,5 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { cityEngine } from './CityEngine.js';
 
 /**
  * 월드 맵에서 플레이어 리더를 제어하는 엔진.
@@ -74,7 +75,23 @@ export class LeaderEngine {
                 y: worldY,
                 ease: 'Sine.easeInOut',
                 duration: 200,
+                onComplete: () => {
+                    this.checkCityInteraction();
+                }
             });
+        }
+    }
+
+    /**
+     * 현재 위치에 도시가 있는지 확인하고, 있다면 해당 도시 씬으로 전환합니다.
+     */
+    checkCityInteraction() {
+        const cities = cityEngine.getCities();
+        const city = cities.find(c => c.tileX === this.tileX && c.tileY === this.tileY);
+
+        if (city) {
+            console.log(`Entering city: ${city.name}`);
+            this.scene.scene.start(city.scene, { cityName: city.name });
         }
     }
 }

--- a/src/game/utils/WorldMapEngine.js
+++ b/src/game/utils/WorldMapEngine.js
@@ -1,4 +1,5 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { cityEngine } from './CityEngine.js';
 
 /**
  * 간단한 월드 맵 엔진. Tilemap API 대신 각 타일을 이미지로 직접 배치합니다.
@@ -41,6 +42,15 @@ export class WorldMapEngine {
                 this.tiles.push(tile);
             }
         }
+
+        // 도시 아이콘을 추가합니다.
+        const cities = cityEngine.getCities();
+        cities.forEach(city => {
+            const cityX = city.tileX * this.TILE_WIDTH;
+            const cityY = city.tileY * this.TILE_HEIGHT;
+            const cityIcon = this.scene.add.image(cityX, cityY, city.icon).setOrigin(0, 0);
+            cityIcon.setDepth(1);
+        });
 
         // 카메라 경계를 설정합니다.
         this.scene.cameras.main.setBounds(0, 0, this.widthInPixels, this.heightInPixels);


### PR DESCRIPTION
## Summary
- manage world map cities via new CityEngine and data file
- draw city icons on the world map and enable entering CityScene
- implement CityScene with building icons and a back button

## Testing
- `for f in tests/*_test.js; do node $f; done`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c86ec1dfc8327b9510785d0e1fb06