### PR TITLE
feat: add stat synergy bonuses for skill selection

### DIFF
--- a/src/game/utils/MercenaryCardSelector.js
+++ b/src/game/utils/MercenaryCardSelector.js
@@ -102,6 +102,26 @@ class MercenaryCardSelector {
                 if (isConventional) score += mercenary.mbti.J;
                 if (!isConventional) score += mercenary.mbti.P;
 
+                // =================================================================
+                // [수정] 스탯 시너지 보너스 시작
+                // =================================================================
+                const finalStats = mercenary.finalStats || {};
+                const scoreMultiplier = 1.5; // 스탯 반영 가중치 (필요시 이 값을 조절하세요)
+
+                if (tags.includes(SKILL_TAGS.MAGIC)) {
+                    // [마법] 태그 스킬은 '지능'에 비례한 보너스를 받습니다.
+                    score += (finalStats.intelligence || 0) * scoreMultiplier;
+                } else if (tags.includes(SKILL_TAGS.MELEE)) {
+                    // [근접] 태그 스킬은 '힘'에 비례한 보너스를 받습니다.
+                    score += (finalStats.strength || 0) * scoreMultiplier;
+                } else if (tags.includes(SKILL_TAGS.RANGED)) {
+                    // [원거리] 태그 스킬은 '민첩'에 비례한 보너스를 받습니다.
+                    score += (finalStats.agility || 0) * scoreMultiplier;
+                }
+                // =================================================================
+                // [수정] 스탯 시너지 보너스 끝
+                // =================================================================
+
                 // ✨ --- [신규] 추가된 태그에 대한 MBTI 선호도 점수 --- ✨
                 // INTJ, ENTJ (전략가, 통솔관)는 전장 통제 스킬을 선호
                 if (tags.includes(SKILL_TAGS.AREA_DENIAL)) score += (mercenary.mbti.N + mercenary.mbti.T) / 2;


### PR DESCRIPTION
## Summary
- incorporate mercenary stats into skill selection scoring

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c8d7abb8483279e7e7fcf23adeb72