### PR TITLE
Add nanomancer skill logic and integrate data

### DIFF
--- a/src/game/data/archetypeTriggers.js
+++ b/src/game/data/archetypeTriggers.js
@@ -1,0 +1,18 @@
+/**
+ * MBTI 조합에 따라 특정 아키타입을 선택하도록 유도하는 트리거 데이터.
+ * 클래스별로 조건을 명시하며, 순서가 앞일수록 우선 적용됩니다.
+ */
+export const archetypeTriggers = {
+    NANOMANCER: [
+        // 기존 프로스트위버는 첫 번째 순서(기본값)로 유지
+        { archetype: 'FROSTWEAVER', mbti: ['I', 'T'] },
+        // 신규 아키타입 추가
+        { archetype: 'ARCANE_BLADE', mbti: ['E', 'S'] },
+        { archetype: 'FORCE_MAJOR', mbti: ['N', 'J'] },
+    ],
+    WARRIOR: [
+        // ... 다른 클래스 트리거 정의
+    ],
+    // ... 추가 클래스
+};
+

--- a/src/game/data/archetypes/arcane_blade.js
+++ b/src/game/data/archetypes/arcane_blade.js
@@ -1,0 +1,28 @@
+import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+
+/**
+ * 아케인 블레이드 (Arcane Blade)
+ * 근접 전투와 마법을 융합하여, 칼과 주문을 동시에 휘두르는 전투 마법사.
+ * 근접, 돌진, 마법, 버프 태그에 높은 가산점을 부여합니다.
+ */
+export const arcaneBladeArchetype = {
+    id: 'ArcaneBlade',
+    name: '아케인 블레이드',
+    description: 'A mage who imbues their weapon with arcane power, seamlessly blending swordplay and sorcery in close-quarters combat.',
+
+    preferredTags: [
+        { tag: SKILL_TAGS.MELEE, weight: 200 },
+        { tag: SKILL_TAGS.CHARGE, weight: 150 },
+        { tag: SKILL_TAGS.MAGIC, weight: 120 },
+        { tag: SKILL_TAGS.BUFF, weight: 100 },
+        // 근접전을 위한 생존기에도 약간의 가산점
+        { tag: 'SHIELD', weight: 50 },
+        { tag: SKILL_TAGS.WILL_GUARD, weight: 50 },
+    ],
+
+    // 아키타입 보너스로 힘 스탯을 약간 부여하여 근접 스킬 효율을 높임
+    startingBonus: {
+        strength: 5,
+    },
+};
+

--- a/src/game/data/archetypes/force_major.js
+++ b/src/game/data/archetypes/force_major.js
@@ -1,0 +1,27 @@
+import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+
+/**
+ * 포스 메이저 (Force Major)
+ * 순수한 힘과 파괴에 집중하여, 압도적인 원거리 마법 피해를 선호합니다.
+ * FORCE, KINETIC, BEAM 태그에 막대한 보너스를 부여합니다.
+ */
+export const forceMajorArchetype = {
+    id: 'ForceMajor',
+    name: '포스 메이저',
+    description: 'A specialist in raw power, who casts aside subtlety to unleash overwhelming waves of pure kinetic and magical force.',
+
+    preferredTags: [
+        { tag: 'FORCE', weight: 250 },
+        { tag: SKILL_TAGS.KINETIC, weight: 200 },
+        { tag: 'BEAM', weight: 180 },
+        // 돌진기 역시 위치 선점을 위해 중요한 스킬로 간주
+        { tag: SKILL_TAGS.CHARGE, weight: 100 },
+        { tag: 'AOE', weight: 80 }, // 광역 피해도 선호
+    ],
+
+    // 아키타입 보너스로 지능을 높여 순수 마법 피해량을 극대화
+    startingBonus: {
+        intelligence: 5,
+    },
+};
+

--- a/src/game/data/archetypes/index.js
+++ b/src/game/data/archetypes/index.js
@@ -2,6 +2,8 @@ import { dreadnoughtArchetype } from './dreadnought.js';
 import { frostweaverArchetype } from './frostweaver.js';
 import { aquiliferArchetype } from './aquilifer.js';
 import { executionerArchetype } from './executioner.js'; // ✨ [추가]
+import { arcaneBladeArchetype } from './arcane_blade.js'; // ✨ [신규]
+import { forceMajorArchetype } from './force_major.js'; // ✨ [신규]
 
 /**
  * 모든 아키타입 정의를 하나의 객체로 통합하여 관리합니다.
@@ -12,6 +14,8 @@ export const archetypes = {
     Frostweaver: frostweaverArchetype,
     Aquilifer: aquiliferArchetype,
     Executioner: executionerArchetype, // ✨ [추가]
+    ArcaneBlade: arcaneBladeArchetype, // ✨ [신규]
+    ForceMajor: forceMajorArchetype, // ✨ [신규]
     // ... 향후 추가될 아키타입들
 };
 

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1558,6 +1558,79 @@ export const activeSkills = {
             damageMultiplier: { min: 0.95, max: 1.05 }
             // 실제 처형 로직은 CombatCalculationEngine에서 처리됩니다.
         }
-    }
+    },
     // --- ▲ [신규] 엑시큐셔너 전용 '암살' 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 나노맨서 전용 스킬 4종 추가 ▼ ---
+    manaStrike: {
+        yinYangValue: -1,
+        NORMAL: {
+            id: 'manaStrike',
+            name: 'Mana Strike',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer'],
+            tags: [SKILL_TAGS.MELEE, SKILL_TAGS.MAGIC, 'ATTACK'],
+            cost: 2,
+            targetType: 'enemy',
+            description: 'Strike a nearby enemy with a mana-infused blade. Damage scales with both Strength and Intelligence.',
+            illustrationPath: null,
+            cooldown: 0,
+            range: 1,
+        },
+    },
+
+    arcaneCharge: {
+        yinYangValue: +2,
+        NORMAL: {
+            id: 'arcaneCharge',
+            name: 'Arcane Charge',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer'],
+            tags: [SKILL_TAGS.CHARGE, 'MOVEMENT', SKILL_TAGS.BUFF, 'SHIELD'],
+            cost: 3,
+            targetType: 'enemy',
+            description: 'Dash towards an enemy up to 3 tiles away. Upon arrival, gain a 10 point magic shield for 1 turn.',
+            illustrationPath: null,
+            cooldown: 2,
+            range: 3,
+            effect: { id: 'arcaneShield', duration: 1, shield: 10 },
+        },
+    },
+
+    forceUnleashed: {
+        yinYangValue: +4,
+        NORMAL: {
+            id: 'forceUnleashed',
+            name: 'Force Unleashed',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer'],
+            tags: ['FORCE', SKILL_TAGS.MAGIC, 'AOE', 'ATTACK'],
+            cost: 4,
+            targetType: 'self',
+            description: 'Emit a devastating shockwave of pure force, hitting all enemies within 2 tiles for heavy magic damage.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 0,
+            aoe: { shape: 'SQUARE', radius: 2 },
+        },
+    },
+
+    kineticBeam: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'kineticBeam',
+            name: 'Kinetic Beam',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer'],
+            tags: ['BEAM', SKILL_TAGS.KINETIC, SKILL_TAGS.RANGED, 'ATTACK'],
+            cost: 3,
+            targetType: 'line',
+            description: 'Fire a concentrated beam of kinetic energy in a straight line, damaging and pushing back all enemies it passes through.',
+            illustrationPath: null,
+            cooldown: 2,
+            range: 4,
+            aoe: { shape: 'LINE', length: 4 },
+        },
+    },
+    // --- ▲ [신규] 나노맨서 전용 스킬 4종 추가 ▲ ---
 };

--- a/src/game/logic/skills/arcane_charge.js
+++ b/src/game/logic/skills/arcane_charge.js
@@ -1,0 +1,35 @@
+import { getEntity, moveTo, applyBuff, findValidTargets } from 'game-engine';
+
+/**
+ * '아케인 차지' 스킬 로직
+ * @param {string} casterId - 시전자 ID
+ * @param {string} targetId - 대상 ID
+ */
+export function executeArcaneCharge(casterId, targetId) {
+  const caster = getEntity(casterId);
+  const target = getEntity(targetId);
+
+  if (!caster || !target) return;
+
+  // 1. 타겟 유효성 검사 (3타일 이내)
+  const validTargets = findValidTargets(casterId, { maxDistance: 3, type: 'enemy' });
+  if (!validTargets.includes(targetId)) {
+    console.error('대상이 너무 멀리 있습니다.');
+    return;
+  }
+
+  // 2. 대상의 인접한 빈 타일로 이동
+  moveTo(casterId, { adjacentTo: targetId });
+
+  // 3. 시전자에게 보호막 버프 적용
+  const shieldBuff = {
+    name: 'Arcane Shield',
+    duration: 1, // 1턴 지속
+    effects: {
+      shield: 10, // 10의 피해를 흡수하는 보호막
+    }
+  };
+  applyBuff(casterId, shieldBuff);
+
+  console.log(`${caster.name}이(가) ${target.name}에게 돌진하고, 10의 마법 보호막을 얻었습니다.`);
+}

--- a/src/game/logic/skills/force_unleashed.js
+++ b/src/game/logic/skills/force_unleashed.js
@@ -1,0 +1,22 @@
+import { getEntity, applyDamage, findEntitiesInRadius } from 'game-engine';
+
+/**
+ * '포스 언리쉬드' 스킬 로직
+ * @param {string} casterId - 시전자 ID
+ */
+export function executeForceUnleashed(casterId) {
+  const caster = getEntity(casterId);
+  if (!caster) return;
+
+  // 1. 시전자 주변 2타일 내의 모든 '적' 찾기
+  const targets = findEntitiesInRadius(casterId, 2, 'enemy');
+
+  console.log(`${caster.name}이(가) 포스 언리쉬드를 시전합니다!`);
+
+  // 2. 찾은 모든 적에게 피해 적용
+  targets.forEach(targetId => {
+    const damage = 12 + Math.floor(caster.stats.intelligence * 0.7); // 지능 계수 추가
+    console.log(`  - ${getEntity(targetId).name}에게 ${damage}의 마법 피해!`);
+    applyDamage(targetId, damage, 'magic');
+  });
+}

--- a/src/game/logic/skills/kinetic_beam.js
+++ b/src/game/logic/skills/kinetic_beam.js
@@ -1,0 +1,26 @@
+import { getEntity, applyDamage, pushEntity, findEntitiesInLine } from 'game-engine';
+
+/**
+ * '키네틱 빔' 스킬 로직
+ * @param {string} casterId - 시전자 ID
+ * @param {object} direction - 빔 방향 (예: {x: 1, y: 0})
+ */
+export function executeKineticBeam(casterId, direction) {
+  const caster = getEntity(casterId);
+  if (!caster) return;
+
+  // 1. 지정한 방향으로 일직선상의 모든 '적' 찾기
+  const targets = findEntitiesInLine(casterId, direction);
+
+  console.log(`${caster.name}이(가) 키네틱 빔을 발사합니다!`);
+
+  // 2. 찾은 모든 적에게 순차적으로 피해 및 넉백 적용
+  targets.forEach(targetId => {
+    const target = getEntity(targetId);
+    const damage = 10 + Math.floor(caster.stats.intelligence * 0.6); // 지능 계수 추가
+
+    console.log(`  - ${target.name}이(가) ${damage}의 피해를 받고 밀려납니다.`);
+    applyDamage(targetId, damage, 'magic');
+    pushEntity(targetId, direction, 1); // 지정된 방향으로 1타일 밀기
+  });
+}

--- a/src/game/logic/skills/mana_strike.js
+++ b/src/game/logic/skills/mana_strike.js
@@ -1,0 +1,20 @@
+import { getEntity, applyDamage } from 'game-engine';
+
+/**
+ * '마나 스트라이크' 스킬 로직
+ * @param {string} casterId - 시전자 ID
+ * @param {string} targetId - 대상 ID
+ */
+export function executeManaStrike(casterId, targetId) {
+  const caster = getEntity(casterId);
+  const target = getEntity(targetId);
+
+  if (!caster || !target) return;
+
+  // 하이브리드 피해 계산 (힘의 50% + 지능의 50%)
+  const hybridDamage = Math.floor(caster.stats.strength * 0.5) +
+    Math.floor(caster.stats.intelligence * 0.5) + 8; // 기본 피해 8 추가
+
+  console.log(`${caster.name}이(가) ${target.name}에게 마나 스트라이크로 ${hybridDamage}의 하이브리드 피해를 입혔습니다.`);
+  applyDamage(targetId, hybridDamage, 'hybrid');
+}

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -154,4 +154,21 @@ for (const base of frostweaverBases) {
     }
 }
 
+// 신규 나노맨서 스킬 검증
+const nanomancerBases = [
+    { id: 'manaStrike', cost: 2, cooldown: 0, tags: ['MELEE', 'MAGIC', 'ATTACK'] },
+    { id: 'arcaneCharge', cost: 3, cooldown: 2, tags: ['CHARGE', 'MOVEMENT', 'BUFF', 'SHIELD'] },
+    { id: 'forceUnleashed', cost: 4, cooldown: 3, tags: ['FORCE', 'MAGIC', 'AOE', 'ATTACK'] },
+    { id: 'kineticBeam', cost: 3, cooldown: 2, tags: ['BEAM', 'KINETIC', 'RANGED', 'ATTACK'] },
+];
+
+for (const base of nanomancerBases) {
+    const skill = skillModifierEngine.getModifiedSkill(base, 'NORMAL');
+    assert.strictEqual(skill.cost, base.cost, `${base.id} cost failed`);
+    assert.strictEqual(skill.cooldown, base.cooldown, `${base.id} cooldown failed`);
+    for (const tag of base.tags) {
+        assert(skill.tags.includes(tag), `${base.id} missing tag ${tag}`);
+    }
+}
+
 console.log('Nanomancer skills integration test passed.');


### PR DESCRIPTION
## Summary
- move Mana Strike, Arcane Charge, Force Unleashed and Kinetic Beam into the active skill catalog
- implement execution logic for each new Nanomancer skill
- adjust Arcane Blade and Force Major archetypes to reference new tag strings

## Testing
- `node tests/nanomancer_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689c9624c96883279c2a6d0f6da96e88