### PR TITLE
feat(ai): add MBTI situation scorer

### DIFF
--- a/src/ai/mbtiProfiles.js
+++ b/src/ai/mbtiProfiles.js
@@ -1,0 +1,25 @@
+export const MBTI_TRAITS = {
+  ENFJ:{ aggression:.55,risk:.35,teamwork:.9,support:.9,focus:.65,kite:.45,burst:.5,sustain:.8,objective:.7 },
+  ENFP:{ aggression:.6 ,risk:.75,teamwork:.6,support:.55,focus:.5 ,kite:.65,burst:.8,sustain:.4,objective:.55 },
+  ENTJ:{ aggression:.85,risk:.6 ,teamwork:.7,support:.25,focus:.85,kite:.35,burst:.75,sustain:.45,objective:.9 },
+  ENTP:{ aggression:.65,risk:.8 ,teamwork:.55,support:.3,focus:.55,kite:.55,burst:.85,sustain:.35,objective:.6 },
+  ESFJ:{ aggression:.4 ,risk:.25,teamwork:.9,support:.9,focus:.6 ,kite:.4 ,burst:.45,sustain:.85,objective:.7 },
+  ESFP:{ aggression:.7 ,risk:.85,teamwork:.55,support:.4,focus:.4 ,kite:.6 ,burst:.75,sustain:.35,objective:.5 },
+  ESTJ:{ aggression:.8 ,risk:.55,teamwork:.7,support:.3,focus:.8 ,kite:.35,burst:.7 ,sustain:.55,objective:.9 },
+  ESTP:{ aggression:.85,risk:.9 ,teamwork:.45,support:.2,focus:.45,kite:.55,burst:.9 ,sustain:.3 ,objective:.55 },
+
+  INFJ:{ aggression:.45,risk:.25,teamwork:.75,support:.8,focus:.8 ,kite:.55,burst:.45,sustain:.8 ,objective:.75 },
+  INFP:{ aggression:.4 ,risk:.35,teamwork:.6 ,support:.7,focus:.55,kite:.6 ,burst:.5 ,sustain:.6 ,objective:.55 },
+  INTJ:{ aggression:.6 ,risk:.35,teamwork:.65,support:.35,focus:.9 ,kite:.5 ,burst:.6 ,sustain:.6 ,objective:.95 },
+  INTP:{ aggression:.5 ,risk:.55,teamwork:.55,support:.3,focus:.85,kite:.55,burst:.65,sustain:.45,objective:.85 },
+  ISFJ:{ aggression:.35,risk:.2 ,teamwork:.85,support:.95,focus:.65,kite:.45,burst:.35,sustain:.9 ,objective:.65 },
+  ISFP:{ aggression:.55,risk:.65,teamwork:.55,support:.45,focus:.45,kite:.6 ,burst:.6 ,sustain:.4 ,objective:.5 },
+  ISTJ:{ aggression:.55,risk:.3 ,teamwork:.7 ,support:.35,focus:.85,kite:.35,burst:.5 ,sustain:.7 ,objective:.9 },
+  ISTP:{ aggression:.65,risk:.7 ,teamwork:.45,support:.25,focus:.75,kite:.6 ,burst:.65,sustain:.45,objective:.7 }
+};
+
+export function getMBTIString(unit){
+  if(!unit?.mbti) return null;
+  const m = unit.mbti;
+  return (m.E>m.I?'E':'I')+(m.S>m.N?'S':'N')+(m.T>m.F?'T':'F')+(m.J>m.P?'J':'P');
+}

--- a/src/ai/patches/registerMBTISituationScorer.js
+++ b/src/ai/patches/registerMBTISituationScorer.js
@@ -1,0 +1,14 @@
+import { skillScoreEngine } from '../../game/utils/SkillScoreEngine.js';
+import { mbtiSituationScore } from '../situation/mbtiSituationScorer.js';
+
+if(!skillScoreEngine.__hasMBTISituationScorer){
+  skillScoreEngine.scorers.push({
+    name: 'MBTISituationScorer',
+    weight: 1.0,
+    logic: (unit, skill, target, allies, enemies) => {
+      try { return mbtiSituationScore(unit, skill, target, allies, enemies); }
+      catch(e){ return 0; }
+    }
+  });
+  skillScoreEngine.__hasMBTISituationScorer = true;
+}

--- a/src/ai/situation/deriveSituation.js
+++ b/src/ai/situation/deriveSituation.js
@@ -1,0 +1,42 @@
+function dist(a,b){
+  if(!a||!b) return 99;
+  const rA = a.row ?? a.y ?? 0, cA = a.col ?? a.x ?? 0;
+  const rB = b.row ?? b.y ?? 0, cB = b.col ?? b.x ?? 0;
+  return Math.abs(rA-rB)+Math.abs(cA-cB);
+}
+function nearestDistanceTo(list,me){
+  let best=Infinity;
+  for(const u of list||[]){
+    if(!u||u===me||u.currentHp<=0) continue;
+    const d=dist(u,me); if(d<best) best=d;
+  }
+  return Number.isFinite(best)?best:99;
+}
+export function deriveSituation(unit,allies=[],enemies=[]){
+  const maxHp = unit?.finalStats?.hp || unit?.maxHp || 1;
+  const hpPct = Math.max(0,Math.min(1,(unit?.currentHp??maxHp)/maxHp));
+
+  const alliesAlive = (allies||[]).filter(a=>a.currentHp>0).length;
+  const enemiesAlive = (enemies||[]).filter(e=>e.currentHp>0).length;
+  const total = Math.max(1, alliesAlive+enemiesAlive);
+  const allyAdvantage = (alliesAlive - enemiesAlive)/total; // -1..+1
+
+  const nearestEnemyDist = nearestDistanceTo(enemies,unit);
+  const nearestAllyDist  = nearestDistanceTo(allies,unit);
+
+  const threatRange = (unit?.finalStats?.range ?? 1)+1;
+  const threatened = nearestEnemyDist <= threatRange;
+  const isolated   = nearestAllyDist >= 4;
+
+  const enemyClose = (enemies||[]).filter(e=>dist(e,unit)<=2 && e.currentHp>0).length;
+  const allyClose  = (allies ||[]).filter(a=>dist(a,unit)<=2 && a.currentHp>0).length;
+
+  const lowHealthAllyCount = (allies||[]).filter(a=>{
+    const mh = a?.finalStats?.hp || a?.maxHp || 1;
+    return a.currentHp>0 && (a.currentHp/mh)<=0.5;
+  }).length;
+
+  return { hpPct, alliesAlive, enemiesAlive, allyAdvantage,
+           nearestEnemyDist, nearestAllyDist, threatened, isolated,
+           enemyClose, allyClose, lowHealthAllyCount };
+}

--- a/src/ai/situation/mbtiSituationScorer.js
+++ b/src/ai/situation/mbtiSituationScorer.js
@@ -1,0 +1,78 @@
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+import { deriveSituation } from './deriveSituation.js';
+import { MBTI_TRAITS, getMBTIString } from '../mbtiProfiles.js';
+
+const DEBUG_MBTI_SITUATION = false;
+
+export function mbtiSituationScore(unit, skillData, target, allies=[], enemies=[]){
+  const mbti = getMBTIString(unit);
+  if(!mbti) return 0;
+  const traits = MBTI_TRAITS[mbti] || MBTI_TRAITS['ISTJ'];
+
+  const S = deriveSituation(unit, allies, enemies);
+  const tags = skillData?.tags || [];
+  let bonus = 0;
+
+  const is = t => tags.includes(t);
+  const preferIf  = (cond,w)=>{ if(cond) bonus+=w; };
+  const penalizeIf=(cond,w)=>{ if(cond) bonus-=w; };
+
+  // 1) 팀플레이/서포트
+  if(is(SKILL_TAGS.HEAL)||is(SKILL_TAGS.AID)||is(SKILL_TAGS.BUFF)){
+    const need = S.lowHealthAllyCount;
+    bonus += traits.support * (need*12 + (S.hpPct<0.5?6:0));
+    bonus += traits.teamwork * (S.allyClose>=2 ? 8 : 0);
+  }
+
+  // 2) 공격/딜
+  if(skillData.type==='ATTACK'||is(SKILL_TAGS.DAMAGE)){
+    const cluster = Math.max(0, S.enemyClose-1);
+    bonus += traits.aggression * (10 + cluster*6);
+    bonus += (traits.risk - 0.5) * (S.allyAdvantage<0 ? 12 : 4);
+  }
+
+  // 3) 처형각
+  if(is(SKILL_TAGS.EXECUTE) && target){
+    const tmh = target?.finalStats?.hp || target?.maxHp || 1;
+    const thp = Math.max(0,Math.min(1,target.currentHp/tmh));
+    preferIf(thp<=0.35, traits.risk*25 + traits.burst*10);
+    penalizeIf(thp>0.6, 6*(1-traits.risk));
+  }
+
+  // 4) 제어/디버프
+  if(is(SKILL_TAGS.CROWD_CONTROL)||is(SKILL_TAGS.DEBUFF)||is(SKILL_TAGS.BIND)||is(SKILL_TAGS.STUN)){
+    bonus += traits.objective * (S.enemyClose>=2 ? 14 : 8);
+    bonus += traits.focus * (S.threatened ? 10 : 0);
+  }
+
+  // 5) 재배치/카이팅
+  if(is(SKILL_TAGS.REPOSITION)||is(SKILL_TAGS.DASH)||is(SKILL_TAGS.KITE)||is(SKILL_TAGS.MOBILITY)){
+    bonus += traits.kite * (S.threatened ? 14 : 4);
+    bonus += traits.teamwork * (S.isolated ? 8 : 0);
+  }
+
+  // 6) 수비/생존
+  if(is(SKILL_TAGS.GUARD)||is(SKILL_TAGS.WILL_GUARD)||is(SKILL_TAGS.SHIELD)){
+    bonus += traits.sustain * (S.threatened ? 16 : 6);
+    bonus += (1 - traits.risk) * (S.allyAdvantage<0 ? 10 : 0);
+  }
+
+  // 7) 보정: 원거리/근접 성향
+  if(is(SKILL_TAGS.RANGED)) bonus += traits.kite * (S.allyAdvantage<=0?6:2);
+  if(is(SKILL_TAGS.MELEE))  bonus += traits.aggression * (S.allyAdvantage>0?8:-6);
+
+  // 8) 저체력 무리수 방지
+  if(S.hpPct < 0.3){
+    bonus += (traits.risk - 0.5) * -18;
+    bonus += (1 - traits.risk) * 6;
+  }
+
+  if(bonus>60) bonus=60;
+  if(bonus<-40) bonus=-40;
+
+  if(DEBUG_MBTI_SITUATION){
+    console.debug('[MBTI×SIT]', unit?.instanceName, { mbti, S, tags, bonus });
+  }
+
+  return bonus;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import StartGame from './game/main.js';
 import { archetypeMemoryEngine } from './game/utils/ArchetypeMemoryEngine.js';
+import './ai/patches/registerMBTISituationScorer.js';
 
 // [6차 강화학습 데이터] - 2025-08-10 로그 기반
 const learnedData_v6 = {


### PR DESCRIPTION
## Summary
- add MBTI trait table and helper to detect MBTI string
- derive quick battlefield features and compute MBTI×situation bonus
- register MBTI situation scorer plugin in SkillScoreEngine

## Testing
- `for f in tests/*_test.js; do node $f > /tmp/test.log && tail -n 1 /tmp/test.log; done` *(fails: 테스트 1 실패: 아퀼리퍼 아키타입이 올바르게 할당되지 않았습니다.)*
- `python3 -m http.server 8000 &` *(terminated)*
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ca7b8d7908327880fcd22fe94ef78