### PR TITLE
fix: adjust archetype tests for new weighting

### DIFF
--- a/tests/archetype_aquilifer_test.js
+++ b/tests/archetype_aquilifer_test.js
@@ -6,7 +6,8 @@ console.log('--- 🏳️ 아퀼리퍼 아키타입 통합 테스트 시작 ---')
 
 // 아키타입 할당을 결정론적으로 만들기 위해 Math.random 고정
 const originalRandom = Math.random;
-Math.random = () => 0.6; // 아퀼리퍼 구간으로 설정
+// 다른 아키타입의 추가로 확률 분포가 바뀌어 범위를 재조정함
+Math.random = () => 0.2; // 아퀼리퍼 확률 구간에 해당하는 값
 
 // 1. 아퀼리퍼에 어울리는 MBTI를 가진 가상 용병 생성
 const mockAquiliferMerc = {

--- a/tests/archetype_frostweaver_test.js
+++ b/tests/archetype_frostweaver_test.js
@@ -6,7 +6,8 @@ console.log('--- ❄️ 프로스트위버 아키타입 통합 테스트 시작 
 
 // Math.random을 고정하여 아키타입 할당을 결정론적으로 만듭니다.
 const originalRandom = Math.random;
-Math.random = () => 0.3; // 프로스트위버 구간에 해당하는 값 선택
+// 아키타입이 늘어나며 확률 분포가 변경되어 값 재조정
+Math.random = () => 0.2; // 프로스트위버 확률 구간에 해당하는 값
 
 // 1. 프로스트위버에 어울리는 MBTI를 가진 가상 용병 생성
 const mockFrostweaverMerc = {


### PR DESCRIPTION
## Summary
- update Aquilifer and Frostweaver archetype tests to use a probability value in the correct range after new archetypes altered distributions

## Testing
- `node tests/archetype_aquilifer_test.js`
- `node tests/archetype_frostweaver_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689caa8d4e988327b070c9fde85d9701