### PR TITLE
avoid duplicate debug logs

### DIFF
--- a/src/game/utils/DebugLogEngine.js
+++ b/src/game/utils/DebugLogEngine.js
@@ -36,8 +36,8 @@ class DebugLogEngine {
 
         const logEntry = {
             timestamp: new Date().toISOString(),
-            level: level,
-            source: source,
+            level,
+            source,
             message: args.map(arg => {
                 try {
                     JSON.stringify(arg);
@@ -47,11 +47,22 @@ class DebugLogEngine {
                 }
             })
         };
-        this.logHistory.push(logEntry);
+
+        const last = this.logHistory[this.logHistory.length - 1];
+        const isDuplicate =
+            last &&
+            last.level === logEntry.level &&
+            last.source === logEntry.source &&
+            JSON.stringify(last.message) === JSON.stringify(logEntry.message);
+        if (!isDuplicate) {
+            this.logHistory.push(logEntry);
+        }
 
         const color = this._getSourceColor(source);
         const consoleMethod = console[level] || console.log;
-        consoleMethod(`%c[${source}]`, `color: ${color}; font-weight: bold;`, ...args);
+        if (!isDuplicate) {
+            consoleMethod(`%c[${source}]`, `color: ${color}; font-weight: bold;`, ...args);
+        }
     }
 
     log(source, ...args) {


### PR DESCRIPTION
## Summary
- prevent duplicate debug logs by skipping consecutive identical entries in DebugLogEngine

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cb2cffc108327a3b5402810412c87