### PR TITLE
refactor: streamline AI skill search and failure handling

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -2,6 +2,7 @@ import { debugLogEngine } from '../game/utils/DebugLogEngine.js';
 import { tokenEngine } from '../game/utils/TokenEngine.js';
 import { skillEngine } from '../game/utils/SkillEngine.js';
 import { aspirationEngine } from '../game/utils/AspirationEngine.js';
+import { NodeState } from './nodes/Node.js';
 import { createMeleeAI } from './behaviors/MeleeAI.js';
 import { createRangedAI } from './behaviors/RangedAI.js';
 import { createHealerAI } from './behaviors/createHealerAI.js';
@@ -265,7 +266,11 @@ class AIManager {
             }
             // --- ▲ [핵심 수정] 혼란 상태 체크 및 타겟 교체 ▲ ---
 
-            await data.behaviorTree.execute(unit, allUnits, currentEnemies);
+            const treeResult = await data.behaviorTree.execute(unit, allUnits, currentEnemies);
+            if (treeResult === NodeState.FAILURE) {
+                debugLogEngine.log('AIManager', `[${unit.instanceName}] 행동 실패 - 루프 종료.`);
+                break;
+            }
 
             const currentTokens = tokenEngine.getTokens(unit.uniqueId);
             const currentSkillsUsedSize = (blackboard.get('usedSkillsThisTurn') || new Set()).size;

--- a/src/ai/BehaviorTree.js
+++ b/src/ai/BehaviorTree.js
@@ -30,8 +30,10 @@ class BehaviorTree {
         this.blackboard.set('allyUnits', allyUnits);
         // --- ▲ [버그 수정] ▲ ---
 
-        // 루트 노드부터 평가를 시작합니다.
-        await this.root.evaluate(unit, this.blackboard);
+        // 루트 노드부터 평가를 시작하고 결과를 반환합니다.
+        const result = await this.root.evaluate(unit, this.blackboard);
+        this.blackboard.set('lastEvaluationState', result);
+        return result;
     }
 }
 

--- a/src/ai/utils/findBestActionForUnit.js
+++ b/src/ai/utils/findBestActionForUnit.js
@@ -28,12 +28,19 @@ export async function findBestActionForUnit(unit, allies = [], enemies = [], use
         const virtualUnit = { ...unit, gridX: movePos.col, gridY: movePos.row };
         const moveCost = Math.abs(unit.gridX - movePos.col) + Math.abs(unit.gridY - movePos.row);
 
+        // 먼저 사용 가능한 스킬만 선별합니다.
+        const availableSkills = [];
         for (const instanceId of equippedSkillInstances) {
             if (!instanceId || usedSkills.has(instanceId)) continue;
             const instData = skillInventoryManager.getInstanceData(instanceId);
             const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
-            if (!skillEngine.canUseSkill(virtualUnit, skillData)) continue;
+            if (skillEngine.canUseSkill(virtualUnit, skillData)) {
+                availableSkills.push({ skillData, instanceId });
+            }
+        }
+        if (availableSkills.length === 0) continue;
 
+        for (const { skillData, instanceId } of availableSkills) {
             const isSelfTarget = skillData.targetType === 'self';
             const candidates = isSelfTarget
                 ? [virtualUnit]


### PR DESCRIPTION
## Summary
- filter usable skills before evaluating actions
- propagate behavior tree results and stop turn loop on failure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cb6777c8883278416a9e8a53d15d3