### PR TITLE
feat: track per-turn movement

### DIFF
--- a/src/game/utils/LeaderEngine.js
+++ b/src/game/utils/LeaderEngine.js
@@ -18,6 +18,12 @@ export class LeaderEngine {
         // 맵의 중앙에서 시작합니다.
         this.tileX = Math.floor(mapEngine.MAP_WIDTH_IN_TILES / 2);
         this.tileY = Math.floor(mapEngine.MAP_HEIGHT_IN_TILES / 2);
+
+        /**
+         * 현재 턴에서 이미 이동했는지 여부
+         * @type {boolean}
+         */
+        this.hasMovedThisTurn = false;
     }
 
     /**
@@ -40,6 +46,11 @@ export class LeaderEngine {
      * @param {'up' | 'down' | 'left' | 'right'} direction
      */
     move(direction) {
+        // 이미 이동했다면 추가 이동을 막습니다.
+        if (this.hasMovedThisTurn) {
+            return;
+        }
+
         let targetX = this.tileX;
         let targetY = this.tileY;
 
@@ -62,6 +73,7 @@ export class LeaderEngine {
 
         if (targetX >= 0 && targetX < this.mapEngine.MAP_WIDTH_IN_TILES &&
             targetY >= 0 && targetY < this.mapEngine.MAP_HEIGHT_IN_TILES) {
+            this.hasMovedThisTurn = true;
             this.tileX = targetX;
             this.tileY = targetY;
 

--- a/src/game/utils/WorldMapTurnEngine.js
+++ b/src/game/utils/WorldMapTurnEngine.js
@@ -26,7 +26,8 @@ export class WorldMapTurnEngine {
      * @param {'up' | 'down' | 'left' | 'right'} direction
      */
     handleMove(direction) {
-        if (!this.isPlayerTurn) return;
+        // 이동이 이미 이루어졌다면 이번 턴에는 추가 이동을 허용하지 않습니다.
+        if (!this.isPlayerTurn || this.leader.hasMovedThisTurn) return;
 
         this.isPlayerTurn = false;
         this.leader.move(direction);
@@ -35,6 +36,7 @@ export class WorldMapTurnEngine {
 
         this.scene.time.delayedCall(200, () => {
             this.isPlayerTurn = true;
+            this.leader.hasMovedThisTurn = false; // 턴 종료 시 이동 플래그 리셋
         });
     }
 }


### PR DESCRIPTION
## Summary
- track if the leader has moved during the current turn
- block extra movement and reset flag at end of turn

## Testing
- `npm test` (fails: Missing script: "test")
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cbba415008327bb2b388675a29481