### PR TITLE
feat: safeguard pathfinder returns

### DIFF
--- a/src/ai/nodes/FindAllyClusterCenterNode.js
+++ b/src/ai/nodes/FindAllyClusterCenterNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 모든 아군 유닛들의 평균 위치(중심점) 근처의 가장 가까운 빈 셀로 이동 경로를 설정하는 노드.
@@ -46,10 +47,13 @@ class FindAllyClusterCenterNode extends Node {
         const bestCell = availableCells[0];
 
         const path = await this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
-        if (path && path.length > 0) {
+        if (Array.isArray(path) && path.length > 0) {
             blackboard.set('movementPath', path);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `아군 중심(${bestCell.col}, ${bestCell.row})으로 경로 설정`);
             return NodeState.SUCCESS;
+        }
+        if (path) {
+            debugLogEngine.warn('FindAllyClusterCenterNode', 'findPath가 배열을 반환하지 않았습니다.', path);
         }
         
         debugAIManager.logNodeResult(NodeState.FAILURE, '아군 중심점으로의 경로 탐색 실패');

--- a/src/ai/nodes/FindMeleeStrategicTargetNode.js
+++ b/src/ai/nodes/FindMeleeStrategicTargetNode.js
@@ -1,6 +1,7 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { formationEngine } from '../../game/utils/FormationEngine.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 class FindMeleeStrategicTargetNode extends Node {
     constructor({ targetManager, pathfinderEngine }) {
@@ -43,7 +44,10 @@ class FindMeleeStrategicTargetNode extends Node {
 
         for (const bestCell of potentialAttackCells) {
             const path = await this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
-            if (path && path.length > 0) return path;
+            if (Array.isArray(path) && path.length > 0) return path;
+            if (path) {
+                debugLogEngine.warn('FindMeleeStrategicTargetNode', 'findPath가 배열을 반환하지 않았습니다.', path);
+            }
         }
         return null;
     }
@@ -66,10 +70,13 @@ class FindMeleeStrategicTargetNode extends Node {
 
         for (const lowHpEnemy of lowHpEnemies) {
             const path = await this._findPathToUnit(unit, lowHpEnemy);
-            if (path && path.length <= movementRange) {
+            if (Array.isArray(path) && path.length <= movementRange) {
                 blackboard.set('movementTarget', lowHpEnemy);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `체력이 적고 도달 가능한 타겟 [${lowHpEnemy.instanceName}] 설정`);
                 return NodeState.SUCCESS;
+            }
+            if (path && !Array.isArray(path)) {
+                debugLogEngine.warn('FindMeleeStrategicTargetNode', '_findPathToUnit이 배열이 아닌 값을 반환했습니다.', path);
             }
         }
 

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 class FindPathToTargetNode extends Node {
     constructor({ pathfinderEngine, formationEngine }) {
@@ -71,7 +72,10 @@ class FindPathToTargetNode extends Node {
 
         for (const bestCell of potentialCells) {
             const path = await this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
-            if (path && path.length > 0) return path;
+            if (Array.isArray(path) && path.length > 0) return path;
+            if (path) {
+                debugLogEngine.warn('FindPathToTargetNode', 'findPath가 배열을 반환하지 않았습니다.', path);
+            }
         }
         return null;
     }

--- a/src/ai/nodes/FindPullPositionNode.js
+++ b/src/ai/nodes/FindPullPositionNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 적에게는 가깝지만, 아군과는 1칸의 거리를 유지하는 최적의 위치를 찾는 노드.
@@ -55,10 +56,12 @@ class FindPullPositionNode extends Node {
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }
             );
-            if (path && path.length > 0) {
+            if (Array.isArray(path) && path.length > 0) {
                 blackboard.set('movementPath', path);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `끌어당기기 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);
                 return NodeState.SUCCESS;
+            } else if (path) {
+                debugLogEngine.warn('FindPullPositionNode', 'findPath가 배열을 반환하지 않았습니다.', path);
             }
         }
 

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 아군을 치유하면서 적에게서 안전한 위치를 탐색합니다.
@@ -61,10 +62,12 @@ class FindSafeHealingPositionNode extends Node {
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }
             );
-            if (path && path.length > 0) {
+            if (Array.isArray(path) && path.length > 0) {
                 blackboard.set('movementPath', path);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `안전한 치유 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);
                 return NodeState.SUCCESS;
+            } else if (path) {
+                debugLogEngine.warn('FindSafeHealingPositionNode', 'findPath가 배열을 반환하지 않았습니다.', path);
             }
         }
 

--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 전투가 잠잠할 때 유리한 위치로 이동하기 위한 위치를 탐색합니다.
@@ -72,13 +73,15 @@ class FindSafeRepositionNode extends Node {
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }
             );
-            if (path && path.length > 0) {
+            if (Array.isArray(path) && path.length > 0) {
                 blackboard.set('movementPath', path);
                 debugAIManager.logNodeResult(
                     NodeState.SUCCESS,
                     `재배치 위치 (${bestCell.col}, ${bestCell.row}) 경로 설정 (Score: ${maxScore.toFixed(2)})`
                 );
                 return NodeState.SUCCESS;
+            } else if (path) {
+                debugLogEngine.warn('FindSafeRepositionNode', 'findPath가 배열을 반환하지 않았습니다.', path);
             }
         }
 

--- a/src/ai/nodes/MoveToUseSkillNode.js
+++ b/src/ai/nodes/MoveToUseSkillNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 import MoveToTargetNode from './MoveToTargetNode.js';
 
 class MoveToUseSkillNode extends Node {
@@ -22,6 +23,13 @@ class MoveToUseSkillNode extends Node {
         let path = blackboard.get('movementPath');
         if (!path) {
             path = await this.pathfinderEngine.findBestPathToAttack(unit, skill, target);
+            if (path && !Array.isArray(path)) {
+                debugLogEngine.warn('MoveToUseSkillNode', 'findBestPathToAttack가 배열이 아닌 값을 반환했습니다.', {
+                    skill: skill.name,
+                    target: target.instanceName,
+                });
+                return NodeState.FAILURE;
+            }
             if (!path) {
                 debugAIManager.logNodeResult(
                     NodeState.FAILURE,

--- a/src/ai/utils/findBestActionForUnit.js
+++ b/src/ai/utils/findBestActionForUnit.js
@@ -4,6 +4,7 @@ import { skillEngine } from '../../game/utils/SkillEngine.js';
 import { skillScoreEngine } from '../../game/utils/SkillScoreEngine.js';
 import { formationEngine } from '../../game/utils/FormationEngine.js';
 import { pathfinderEngine } from '../../game/utils/PathfinderEngine.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 이동과 스킬 사용을 세트로 평가하여 최적의 행동을 찾습니다.
@@ -16,7 +17,11 @@ import { pathfinderEngine } from '../../game/utils/PathfinderEngine.js';
 export async function findBestActionForUnit(unit, allies = [], enemies = [], usedSkills = new Set()) {
     let bestAction = { move: null, skill: null, target: null, score: -Infinity };
 
-    const possibleMoves = pathfinderEngine.findAllReachableTiles(unit);
+    let possibleMoves = pathfinderEngine.findAllReachableTiles(unit);
+    if (!Array.isArray(possibleMoves)) {
+        debugLogEngine.warn('findBestActionForUnit', 'findAllReachableTiles가 배열을 반환하지 않았습니다.', possibleMoves);
+        possibleMoves = [];
+    }
     // 현재 위치도 포함
     if (!possibleMoves.some(p => p.col === unit.gridX && p.row === unit.gridY)) {
         possibleMoves.push({ col: unit.gridX, row: unit.gridY });


### PR DESCRIPTION
## Summary
- validate pathfinder return values and fall back to empty paths if needed
- ensure AI nodes handle non-array paths and log detailed warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/pathfinder_flyingmen_bug_test.js`
- `node tests/find_path_to_target_node_test.js`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cd7f00fd083279b9cc2797600889e