### PR TITLE
feat: add global action queue

### DIFF
--- a/src/game/dom/TurnOrderUIManager.js
+++ b/src/game/dom/TurnOrderUIManager.js
@@ -16,11 +16,11 @@ export class TurnOrderUIManager {
 
     /**
      * 턴 순서 UI를 표시하고 초기화합니다.
-     * @param {Array<object>} initialTurnQueue - 최초 턴 순서 배열
+     * @param {Array<object>} initialQueue - 최초 액션 큐
      */
-    show(initialTurnQueue) {
+    show(initialQueue) {
         this.container.innerHTML = '';
-        this.update(initialTurnQueue);
+        this.update(initialQueue);
         this.container.style.display = 'block';
     }
 
@@ -33,13 +33,14 @@ export class TurnOrderUIManager {
 
     /**
      * 새로운 턴 순서에 맞춰 UI를 다시 그립니다.
-     * @param {Array<object>} newTurnQueue - 갱신된 턴 순서 배열
+     * @param {Array<object>} newQueue - 갱신된 액션 큐
      */
-    update(newTurnQueue) {
+    update(newQueue) {
         this.container.innerHTML = '';
 
-        newTurnQueue.forEach(unit => {
-            if (unit.currentHp <= 0) return;
+        newQueue.forEach(entry => {
+            const unit = entry.unitId ? turnOrderManager.getUnit(entry.unitId) : entry;
+            if (!unit || unit.currentHp <= 0) return;
 
             const unitEntry = document.createElement('div');
             unitEntry.className = 'turn-order-entry';

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -435,7 +435,10 @@ class SkillEffectProcessor {
             tokenEngine.addTokens(unit.uniqueId, skill.generatesToken.amount, `${skill.name} 효과`);
         }
         if (skill.turnOrderEffect === 'pushToBack' && this.battleSimulator) {
-            this.battleSimulator.turnQueue = turnOrderManager.pushToBack(this.battleSimulator.turnQueue, target);
+            this.battleSimulator.actionQueue = turnOrderManager.pushToBack(
+                this.battleSimulator.actionQueue,
+                target
+            );
         }
         if (skill.push > 0) {
             await formationEngine.pushUnit(target, unit, skill.push, this.animationEngine);

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -1,43 +1,99 @@
 import { debugLogEngine } from './DebugLogEngine.js';
 
 /**
- * 유닛의 스탯에 따라 전투의 턴 순서를 결정하고 관리하는 매니저
+ * 유닛의 행동을 수집하고 이니셔티브에 따라 처리 순서를 정하는 매니저
  */
 class TurnOrderManager {
     constructor() {
+        this.actionQueue = [];
+        this.unitRegistry = new Map();
         debugLogEngine.log('TurnOrderManager', '턴 순서 매니저가 초기화되었습니다.');
     }
 
     /**
-     * 유닛 목록을 받아 무게(weight)가 낮은 순서대로 정렬하여 턴 큐를 생성합니다.
-     * @param {Array<object>} allUnits - 전투에 참여하는 모든 유닛 목록
-     * @returns {Array<object>} - 턴 순서에 따라 정렬된 유닛 배열
+     * 외부에서 전달된 콜백으로 각 유닛의 행동을 수집해 전역 큐에 저장합니다.
+     * @param {Array<object>} units - 행동을 수집할 유닛 목록
+     * @param {(unit:object)=>{action:string,initiative:number}} [resolver]
+     *        - 유닛별 행동과 이니셔티브를 반환하는 콜백
+     * @returns {Array<object>} 수집된 액션 큐
      */
-    createTurnQueue(allUnits) {
-        // ✨ StatEngine이 계산한 turnValue를 기준으로 정렬합니다.
-        const turnQueue = [...allUnits].sort((a, b) => (a.finalStats.turnValue ?? 0) - (b.finalStats.turnValue ?? 0));
+    collectActions(units, resolver = (u) => ({ action: 'wait', initiative: u.finalStats?.turnValue ?? 0 })) {
+        this.actionQueue = [];
+        this.unitRegistry.clear();
 
-        // ✨ 로그에 turnValue를 표시합니다.
-        const turnOrderNames = turnQueue.map(u => `${u.instanceName}(w:${u.finalStats.turnValue})`).join(' -> ');
-        debugLogEngine.log('TurnOrderManager', `턴 순서 결정: ${turnOrderNames}`);
+        units.forEach(unit => {
+            this.unitRegistry.set(unit.uniqueId, unit);
+            const result = resolver(unit);
+            if (result && result.action !== undefined) {
+                this.actionQueue.push({
+                    unitId: unit.uniqueId,
+                    action: result.action,
+                    initiative: result.initiative ?? 0
+                });
+            }
+        });
 
-        return turnQueue;
+        return this.actionQueue;
     }
 
     /**
-     * 특정 유닛을 턴 큐의 가장 마지막으로 이동시킵니다.
-     * @param {Array<object>} turnQueue - 현재 턴 큐
-     * @param {object} targetUnit - 순서를 변경할 대상 유닛
-     * @returns {Array<object>} - 변경된 턴 큐
+     * 수집된 액션 큐를 이니셔티브 순서대로 정렬합니다.
+     * @returns {Array<object>} - 정렬된 액션 큐
      */
-    pushToBack(turnQueue, targetUnit) {
-        const index = turnQueue.findIndex(u => u.uniqueId === targetUnit.uniqueId);
+    createTurnQueue() {
+        const sorted = [...this.actionQueue].sort((a, b) => {
+            if (b.initiative === a.initiative) {
+                return this.resolveInitiativeConflict(a, b);
+            }
+            return b.initiative - a.initiative;
+        });
+
+        const orderNames = sorted
+            .map(e => `${this.unitRegistry.get(e.unitId)?.instanceName}(i:${e.initiative})`)
+            .join(' -> ');
+        debugLogEngine.log('TurnOrderManager', `액션 순서 결정: ${orderNames}`);
+
+        this.actionQueue = sorted;
+        return this.actionQueue;
+    }
+
+    /**
+     * 동일한 이니셔티브가 충돌했을 때 호출되는 훅
+     * 기본 동작은 무작위로 우선 순위를 정합니다.
+     * @param {object} a
+     * @param {object} b
+     * @returns {number} 정렬용 비교 값
+     */
+    resolveInitiativeConflict(a, b) {
+        return Math.random() < 0.5 ? -1 : 1;
+    }
+
+    /**
+     * 특정 유닛의 다음 행동을 액션 큐의 뒤로 보냅니다.
+     * @param {Array<object>} queue - 현재 액션 큐
+     * @param {object} targetUnit - 이동 대상 유닛
+     * @returns {Array<object>} 변경된 액션 큐
+     */
+    pushToBack(queue, targetUnit) {
+        const isActionQueue = queue[0] && queue[0].unitId !== undefined;
+        const index = queue.findIndex(entry =>
+            isActionQueue ? entry.unitId === targetUnit.uniqueId : entry.uniqueId === targetUnit.uniqueId
+        );
         if (index > -1) {
-            const [unit] = turnQueue.splice(index, 1);
-            turnQueue.push(unit);
-            debugLogEngine.log('TurnOrderManager', `'${targetUnit.instanceName}'의 턴 순서가 마지막으로 변경되었습니다.`);
+            const [entry] = queue.splice(index, 1);
+            queue.push(entry);
+            debugLogEngine.log('TurnOrderManager', `'${targetUnit.instanceName}'의 순서가 마지막으로 변경되었습니다.`);
         }
-        return turnQueue;
+        return queue;
+    }
+
+    /**
+     * 저장된 유닛 레지스트리에서 ID로 유닛을 조회합니다.
+     * @param {string|number} id
+     * @returns {object|undefined}
+     */
+    getUnit(id) {
+        return this.unitRegistry.get(id);
     }
 }
 


### PR DESCRIPTION
## Summary
- add global action queue and initiative sorting
- process actions in battle loop and refresh each round
- update turn order UI and skills to handle action queue

## Testing
- `node --test tests`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cdb871748832796a3fcbd38dd8364