### PR TITLE
Implement planning/resolution phases in battle engine

### DIFF
--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -1,3 +1,5 @@
+import { turnOrderManager } from './TurnOrderManager.js';
+
 /**
  * 전투 로직의 기반이 되는 엔진
  * 현재는 간단한 구조만 제공하며, 이후 전투 기능 구현 시 확장될 예정이다.
@@ -16,7 +18,8 @@ class BattleEngine {
         this.currentBattle = {
             allies,
             enemies,
-            turn: 0
+            turn: 1,
+            phase: 'planning'
         };
         console.log('Battle started', this.currentBattle);
     }
@@ -27,7 +30,18 @@ class BattleEngine {
      */
     update() {
         if (!this.currentBattle) return;
-        // TODO: turn processing logic
+
+        const battle = this.currentBattle;
+        if (battle.phase === 'planning') {
+            const units = [...battle.allies, ...battle.enemies];
+            turnOrderManager.collectActions(units);
+            turnOrderManager.createTurnQueue();
+            battle.phase = 'resolution';
+        } else if (battle.phase === 'resolution') {
+            turnOrderManager.resolve();
+            battle.turn += 1;
+            battle.phase = 'planning';
+        }
     }
 
     /**

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -58,6 +58,20 @@ class TurnOrderManager {
     }
 
     /**
+     * 정렬된 액션 큐를 순서대로 실행합니다.
+     * 실제 행동 적용 로직은 추후 구현됩니다.
+     */
+    resolve() {
+        this.actionQueue.forEach(entry => {
+            const unit = this.getUnit(entry.unitId);
+            const name = unit?.instanceName ?? 'Unknown';
+            debugLogEngine.log('TurnOrderManager', `${name}가 '${entry.action}'를 실행합니다.`);
+            // TODO: 실제 액션 처리 로직
+        });
+        this.actionQueue = [];
+    }
+
+    /**
      * 동일한 이니셔티브가 충돌했을 때 호출되는 훅
      * 기본 동작은 무작위로 우선 순위를 정합니다.
      * @param {object} a


### PR DESCRIPTION
## Summary
- add planning/resolution phase cycle to `BattleEngine` with turn counter
- implement `resolve` execution method in `TurnOrderManager`

## Testing
- `node tests/gunner_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689cde1223688327a9014e7501196878