### PR TITLE
feat: show planned actions with tokens

### DIFF
--- a/src/game/dom/CombatUIManager.js
+++ b/src/game/dom/CombatUIManager.js
@@ -28,6 +28,7 @@ export class CombatUIManager {
         this.battleSpeedManager = battleSpeedManager;
         this.currentUnitId = null; // 현재 표시 중인 유닛 ID
         this.skillIcons = [];      // 스킬 아이콘 요소들을 저장할 배열
+        this.onConfirmPlanning = null; // 계획 확정 콜백
 
         // UI 구조를 미리 생성합니다.
         this._createBaseLayout();
@@ -105,11 +106,22 @@ export class CombatUIManager {
             this.speedButton.innerText = `${newSpeed}x`;
         };
 
+        this.confirmButton = document.createElement('button');
+        this.confirmButton.id = 'confirm-actions-btn';
+        this.confirmButton.textContent = '행동 확정';
+        this.confirmButton.className = 'battle-control-button';
+        this.confirmButton.onclick = () => {
+            if (this.onConfirmPlanning) this.onConfirmPlanning();
+        };
+        this.confirmButton.style.display = 'none';
+
         this.instantResultButton = document.createElement('button');
         this.instantResultButton.id = 'instant-result-btn';
         this.instantResultButton.textContent = '전투 종료 결과';
         this.instantResultButton.className = 'battle-control-button';
+
         controlsContainer.appendChild(this.speedButton);
+        controlsContainer.appendChild(this.confirmButton);
         controlsContainer.appendChild(this.instantResultButton);
 
         const rightPanel = document.createElement('div');
@@ -119,6 +131,24 @@ export class CombatUIManager {
 
         this.container.appendChild(infoPanel);
         this.container.appendChild(rightPanel);
+    }
+
+    /**
+     * 계획 확정 버튼 표시 여부를 토글합니다.
+     * @param {boolean} show
+     */
+    toggleConfirmButton(show) {
+        if (this.confirmButton) {
+            this.confirmButton.style.display = show ? 'inline-block' : 'none';
+        }
+    }
+
+    /**
+     * 계획 확정 버튼 클릭 시 호출될 핸들러를 등록합니다.
+     * @param {Function} handler
+     */
+    setConfirmPlanningHandler(handler) {
+        this.onConfirmPlanning = handler;
     }
 
     _setupInstantResultButton() {

--- a/src/game/dom/TurnOrderUIManager.js
+++ b/src/game/dom/TurnOrderUIManager.js
@@ -1,4 +1,5 @@
 import { turnOrderManager } from '../utils/TurnOrderManager.js';
+import { tokenEngine } from '../utils/TokenEngine.js';
 
 /**
  * 전투 중 턴 순서 UI를 관리하는 DOM 매니저
@@ -11,6 +12,12 @@ export class TurnOrderUIManager {
             this.container.id = 'turn-order-container';
             document.getElementById('ui-container').appendChild(this.container);
         }
+
+        // 실제 항목을 담을 리스트를 미리 만들어둔다.
+        this.listElem = document.createElement('div');
+        this.listElem.className = 'turn-order-list';
+        this.container.appendChild(this.listElem);
+
         this.container.style.display = 'none';
     }
 
@@ -19,7 +26,6 @@ export class TurnOrderUIManager {
      * @param {Array<object>} initialQueue - 최초 액션 큐
      */
     show(initialQueue) {
-        this.container.innerHTML = '';
         this.update(initialQueue);
         this.container.style.display = 'block';
     }
@@ -36,7 +42,7 @@ export class TurnOrderUIManager {
      * @param {Array<object>} newQueue - 갱신된 액션 큐
      */
     update(newQueue) {
-        this.container.innerHTML = '';
+        this.listElem.innerHTML = '';
 
         newQueue.forEach(entry => {
             const unit = entry.unitId ? turnOrderManager.getUnit(entry.unitId) : entry;
@@ -44,9 +50,6 @@ export class TurnOrderUIManager {
 
             const unitEntry = document.createElement('div');
             unitEntry.className = 'turn-order-entry';
-            if (unit.isTurnActive) {
-                unitEntry.classList.add('active-turn');
-            }
 
             const portrait = document.createElement('div');
             portrait.className = 'turn-order-portrait';
@@ -57,9 +60,25 @@ export class TurnOrderUIManager {
             nameLabel.className = 'turn-order-name';
             nameLabel.innerText = unit.instanceName;
 
+            const actionLabel = document.createElement('span');
+            actionLabel.className = 'turn-order-action';
+            actionLabel.innerText = entry.action || '대기';
+
+            const tokenContainer = document.createElement('div');
+            tokenContainer.className = 'turn-order-token-container';
+            const tokens = tokenEngine.getTokens(unit.uniqueId);
+            for (let i = 0; i < tokens; i++) {
+                const tokenImg = document.createElement('img');
+                tokenImg.src = 'assets/images/battle/token.png';
+                tokenImg.className = 'turn-order-token-icon';
+                tokenContainer.appendChild(tokenImg);
+            }
+
             unitEntry.appendChild(portrait);
             unitEntry.appendChild(nameLabel);
-            this.container.appendChild(unitEntry);
+            unitEntry.appendChild(actionLabel);
+            unitEntry.appendChild(tokenContainer);
+            this.listElem.appendChild(unitEntry);
         });
     }
 


### PR DESCRIPTION
## Summary
- list each unit's planned action with remaining tokens in turn order display
- add planning confirmation control

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ce07a0248832788188ccfdb740eba