### PR TITLE
Compute speed from agility/weight and add initiative gauge

### DIFF
--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -199,7 +199,8 @@ class StatEngine {
             'movement', 'attackRange', 'weight', 'physicalAttack', 'magicAttack', 'rangedAttack',
             'physicalDefense', 'magicDefense', 'rangedDefense', 'criticalChance', 'criticalDamageMultiplier',
             'physicalEvadeChance', 'magicEvadeChance', 'statusEffectResistance', 'statusEffectApplication',
-            'maxBarrier', 'currentBarrier', 'totalWeight', 'turnValue', 'physicalAttackPercentage', 'magicAttackPercentage'
+            'maxBarrier', 'currentBarrier', 'totalWeight', 'turnValue', 'speed', 'initiativeGauge',
+            'physicalAttackPercentage', 'magicAttackPercentage'
         ];
 
         allStatKeys.forEach(key => {
@@ -228,6 +229,8 @@ class StatEngine {
         finalStats.totalWeight = this.weightEngine.calculateTotalWeight(unitData);
         finalStats.weight = finalStats.totalWeight;
         finalStats.turnValue = this.weightEngine.getTurnValue(finalStats.totalWeight, finalStats.agility);
+        finalStats.speed = Math.max(1, finalStats.agility - finalStats.weight * 0.2);
+        finalStats.initiativeGauge = 0;
 
         return finalStats;
     }


### PR DESCRIPTION
## Summary
- derive unit speed from agility minus weight
- track initiative gauge on final stats
- ensure all unit templates provide agility and weight for speed calculations

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ce6773c748327a0a6a0d4c050edb0