### PR TITLE
feat: manage initiative gauge in turn order

### DIFF
--- a/src/game/utils/InitiativeGaugeEngine.js
+++ b/src/game/utils/InitiativeGaugeEngine.js
@@ -1,0 +1,33 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 단순한 이니셔티브 게이지 관리 엔진
+ */
+class InitiativeGaugeEngine {
+    constructor() {
+        this.units = new Map();
+        debugLogEngine.log('InitiativeGaugeEngine', '이니셔티브 게이지 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 게이지 관리를 위해 유닛을 등록합니다.
+     * @param {object} unit
+     */
+    registerUnit(unit) {
+        this.units.set(unit.uniqueId, unit);
+    }
+
+    /**
+     * 지정된 유닛의 게이지를 0으로 초기화합니다.
+     * @param {string|number} unitId
+     */
+    resetGauge(unitId) {
+        const unit = this.units.get(unitId);
+        if (unit?.finalStats) {
+            unit.finalStats.initiativeGauge = 0;
+            debugLogEngine.log('InitiativeGaugeEngine', `${unit.instanceName}의 이니셔티브 게이지가 리셋되었습니다.`);
+        }
+    }
+}
+
+export const initiativeGaugeEngine = new InitiativeGaugeEngine();


### PR DESCRIPTION
## Summary
- skip units whose initiative gauge is below readiness threshold
- expose `onGaugeFilled` hook and reset gauges after each turn
- provide minimal `InitiativeGaugeEngine` for tracking gauges

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ce67945288327b23be467a954fb22