### PR TITLE
gate AI planning by initiative

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -221,7 +221,7 @@ class AIManager {
         if (!data) {
             return {
                 action: async () => {},
-                initiative: unit.finalStats?.turnValue ?? 0
+                initiative: unit.finalStats?.speed ?? 0
             };
         }
 

--- a/src/ai/BehaviorTree.js
+++ b/src/ai/BehaviorTree.js
@@ -46,7 +46,7 @@ class BehaviorTree {
      * @returns {{action: Function, initiative: number}}
      */
     planAction(unit, allUnits, enemyUnits) {
-        const initiative = unit.finalStats?.turnValue ?? 0;
+        const initiative = unit.finalStats?.speed ?? 0;
 
         // action은 나중에 실행 단계에서 호출될 함수입니다.
         const action = async () => {

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -23,13 +23,15 @@ class TurnOrderManager {
 
         units.forEach(unit => {
             this.unitRegistry.set(unit.uniqueId, unit);
-            const result = resolver(unit);
-            if (result && result.action !== undefined) {
-                this.actionQueue.push({
-                    unitId: unit.uniqueId,
-                    action: result.action,
-                    initiative: result.initiative ?? 0
-                });
+            if (unit.finalStats?.initiativeGauge >= 100) {
+                const result = resolver(unit);
+                if (result && result.action !== undefined) {
+                    this.actionQueue.push({
+                        unitId: unit.uniqueId,
+                        action: result.action,
+                        initiative: result.initiative ?? 0
+                    });
+                }
             }
         });
 
@@ -74,6 +76,7 @@ class TurnOrderManager {
             }
         }
         this.actionQueue = [];
+        this.unitRegistry.clear();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Only collect AI plans for units with full initiative gauge
- Use unit speed as initiative when planning AI actions
- Reset turn order state after actions resolve to avoid stale plans

## Testing
- `python3 -m http.server 8000 &` / `curl http://localhost:8000/debug.html | head -n 20`
- `node tests/pathfinder_flyingmen_bug_test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce67bfbac8327b4ff58c523c936bb