### PR TITLE
Add initiative gauge engine and integrate with turn order

### DIFF
--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -24,15 +24,13 @@ class TurnOrderManager {
 
         units.forEach(unit => {
             this.unitRegistry.set(unit.uniqueId, unit);
-            if (unit.finalStats?.initiativeGauge >= 100) {
-                const result = resolver(unit);
-                if (result && result.action !== undefined) {
-                    this.actionQueue.push({
-                        unitId: unit.uniqueId,
-                        action: result.action,
-                        initiative: result.initiative ?? 0
-                    });
-                }
+            const result = resolver(unit);
+            if (result && result.action !== undefined) {
+                this.actionQueue.push({
+                    unitId: unit.uniqueId,
+                    action: result.action,
+                    initiative: result.initiative ?? 0
+                });
             }
         });
 
@@ -64,7 +62,7 @@ class TurnOrderManager {
      * 정렬된 액션 큐를 순서대로 실행합니다.
      * 실제 행동 적용 로직은 추후 구현됩니다.
      */
-    async resolve() {
+    async resolve(onResolved) {
         for (const entry of this.actionQueue) {
             const unit = this.getUnit(entry.unitId);
             const name = unit?.instanceName ?? 'Unknown';
@@ -74,6 +72,10 @@ class TurnOrderManager {
                 await entry.action();
             } else {
                 debugLogEngine.log('TurnOrderManager', `${name}가 '${entry.action}'를 실행합니다.`);
+            }
+
+            if (onResolved) {
+                onResolved(entry.unitId);
             }
         }
         this.actionQueue = [];

--- a/tests/initiative_gauge_test.js
+++ b/tests/initiative_gauge_test.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { InitiativeGaugeEngine } from '../src/game/utils/InitiativeGaugeEngine.js';
+import { turnOrderManager } from '../src/game/utils/TurnOrderManager.js';
+
+console.log('--- ⚖️ 이니셔티브 게이지 엔진 테스트 시작 ---');
+
+const initiativeGaugeEngine = new InitiativeGaugeEngine();
+
+const fastUnit = { uniqueId: 'fast', instanceName: '빠른 유닛', speed: 10 };
+const slowUnit = { uniqueId: 'slow', instanceName: '느린 유닛', speed: 5 };
+
+let fastCount = 0;
+let slowCount = 0;
+let fastFirstTick = null;
+let slowFirstTick = null;
+
+for (let tick = 1; tick <= 40; tick++) {
+    const ready = initiativeGaugeEngine.tick([fastUnit, slowUnit]);
+    if (ready.length) {
+        turnOrderManager.collectActions(ready, u => ({ action: 'act', initiative: u.speed }));
+        const queue = turnOrderManager.createTurnQueue();
+        queue.forEach(entry => {
+            const unit = entry.unitId === fastUnit.uniqueId ? fastUnit : slowUnit;
+            if (entry.unitId === fastUnit.uniqueId) {
+                fastCount++;
+                if (fastFirstTick === null) fastFirstTick = tick;
+            } else {
+                slowCount++;
+                if (slowFirstTick === null) slowFirstTick = tick;
+            }
+            initiativeGaugeEngine.resetGauge(unit);
+            assert.strictEqual(
+                initiativeGaugeEngine.getGauge(unit),
+                0,
+                `${unit.instanceName}의 게이지가 초기화되지 않았습니다.`
+            );
+        });
+    }
+}
+
+assert(fastFirstTick < slowFirstTick, '빠른 유닛이 먼저 행동하지 않았습니다.');
+assert(fastCount > slowCount, '빠른 유닛의 행동 횟수가 더 많아야 합니다.');
+
+console.log('✅ 빠른 유닛이 먼저이자 더 자주 턴을 얻었습니다.');
+console.log('✅ 행동 후 게이지가 0으로 초기화되었습니다.');
+


### PR DESCRIPTION
## Summary
- Add simple InitiativeGaugeEngine to track unit gauges and expose register, tick, reset, and clear helpers
- Wire BattleEngine and TurnOrderManager to use the gauge engine for action collection and resolution
- Cover gauge behaviour with a dedicated initiative_gauge_test

## Testing
- `node tests/initiative_gauge_test.js`
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ce86dc4f88327a659ac606276b308