### PR TITLE
Integrate battleEngine into arena scene

### DIFF
--- a/src/game/scenes/ArenaBattleScene.js
+++ b/src/game/scenes/ArenaBattleScene.js
@@ -5,6 +5,7 @@ import { partyEngine } from '../utils/PartyEngine.js';
 import { BattleSimulatorEngine } from '../utils/BattleSimulatorEngine.js';
 import { arenaManager } from '../utils/ArenaManager.js';
 import { logDownloader } from '../utils/LogDownloader.js'; // logDownloader import 추가
+import { battleEngine } from '../utils/BattleEngine.js'; // battleEngine import 추가
 
 export class ArenaBattleScene extends Scene {
     constructor() {
@@ -35,7 +36,8 @@ export class ArenaBattleScene extends Scene {
         const partyUnits = partyEngine.getDeployedMercenaries();
         const enemyUnits = arenaManager.getEnemyTeam();
 
-        this.battleSimulator.start(partyUnits, enemyUnits);
+        // battleSimulator.start 대신 battleEngine.startBattle을 사용
+        battleEngine.startBattle(partyUnits, enemyUnits);
 
         // ✨ 'L' 키를 누르면 로그를 다운로드하는 이벤트 리스너를 추가합니다.
         this.input.keyboard.on('keydown-L', () => {
@@ -50,5 +52,9 @@ export class ArenaBattleScene extends Scene {
             if (this.cameraControl) this.cameraControl.destroy();
             if (this.battleSimulator) this.battleSimulator.shutdown();
         });
+    }
+
+    update(time, delta) {
+        battleEngine.update(delta);
     }
 }

--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -34,6 +34,7 @@ class BattleEngine {
 
     /**
      * 매 프레임 호출되어 전투를 진행한다.
+     * initiativeGaugeEngine을 활용해 행동 준비가 된 유닛들의 차례를 동시에 처리한다.
      * @param {number} [deltaMs]
      */
     async update(deltaMs) {


### PR DESCRIPTION
## Summary
- Use `battleEngine.startBattle` in ArenaBattleScene and update battle each frame
- Clarify BattleEngine's update comment around initiative gauge processing

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ceada3d908327be58e0e244e03118