### PR TITLE
Fix buff self-damage, taunt damage, and commander range

### DIFF
--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -231,7 +231,7 @@ export const mercenaryData = {
         baseStats: {
             hp: 110, valor: 12, strength: 13, endurance: 11,
             agility: 9, intelligence: 7, wisdom: 8, luck: 7,
-            attackRange: 1,
+            attackRange: 2,
             movement: 3,
             weight: 18
         },

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -113,6 +113,7 @@ export const activeSkills = {
             illustrationPath: null,
             cooldown: 3,
             range: 0,
+            damageMultiplier: 0,
             aoe: { shape: 'SQUARE', radius: 3 },
             effect: {
                 id: 'tauntDebuff',

--- a/src/game/logic/skills/new_skill_cards.js
+++ b/src/game/logic/skills/new_skill_cards.js
@@ -54,28 +54,6 @@ export const newActiveSkills = {
         }
     },
 
-    // 그림자 이동: 위치 이동 및 다음 공격 강화
-    shadowStep: {
-        yinYangValue: -1,
-        NORMAL: {
-            id: 'shadowStep',
-            name: '그림자 이동',
-            type: 'ACTIVE',
-            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.DARK, SKILL_TAGS.SPECIAL],
-            cost: 1,
-            targetType: 'self',
-            description: '그림자 속으로 숨어 순간이동합니다. 지정한 위치(최대 3칸)로 이동하며 다음 공격이 20% 증가합니다.',
-            illustrationPath: null,
-            cooldown: 2,
-            range: 3,
-            effect: {
-                id: 'shadowStepBuff',
-                type: EFFECT_TYPES.BUFF,
-                duration: 1,
-                modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.20 }
-            }
-        }
-    },
 
     // 연쇄 번개: 여러 대상을 연쇄적으로 공격
     chainLightning: {
@@ -171,6 +149,29 @@ export const newBuffSkills = {
                     { stat: 'movement', type: 'flat', value: 2 },
                     { stat: 'evasion', type: 'percentage', value: 0.10 }
                 ]
+            }
+        }
+    },
+
+    // 그림자 이동: 위치 이동 및 다음 공격 강화
+    shadowStep: {
+        yinYangValue: -1,
+        NORMAL: {
+            id: 'shadowStep',
+            name: '그림자 이동',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.DARK, SKILL_TAGS.SPECIAL],
+            cost: 1,
+            targetType: 'self',
+            description: '그림자 속으로 숨어 순간이동합니다. 지정한 위치(최대 3칸)로 이동하며 다음 공격이 20% 증가합니다.',
+            illustrationPath: null,
+            cooldown: 2,
+            range: 3,
+            effect: {
+                id: 'shadowStepBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.20 }
             }
         }
     },

--- a/tests/class_passive_integration_test.js
+++ b/tests/class_passive_integration_test.js
@@ -169,6 +169,7 @@ combatCalculationEngine.battleSimulator = battleSimulator;
 
 // -------------------- Commander - Commander's Shout --------------------
 {
+  assert.strictEqual(mercenaryData.commander.baseStats.attackRange, 2, 'Commander attack range should be 2');
   const commander = { uniqueId:1, id:'commander', instanceName:'Cmd', team:'ally' };
   const strategySkill = { id:'tactics', name:'Tactics', cost:0, cooldown:10, tags:[SKILL_TAGS.STRATEGY] };
   skillEngine.recordSkillUse(commander, strategySkill);

--- a/tests/new_skill_cards_integration_test.js
+++ b/tests/new_skill_cards_integration_test.js
@@ -29,5 +29,11 @@ newSkillIds.forEach(id => {
   assert(count >= 5, `${id} should be added to inventory at game start`);
 });
 
+assert.strictEqual(
+  skillCardDatabase.shadowStep.NORMAL.type,
+  'BUFF',
+  'shadowStep should be registered as a buff skill'
+);
+
 console.log('--- New skill cards integration test passed ---');
 

--- a/tests/sentinel_skill_integration_test.js
+++ b/tests/sentinel_skill_integration_test.js
@@ -73,6 +73,7 @@ console.log('✅ 클래스 패시브 테스트 통과');
 const tauntSkill = activeSkills.taunt.NORMAL;
 assert(tauntSkill && tauntSkill.cooldown === 3, '도발 스킬의 기본 쿨타임이 3이어야 합니다.');
 assert(tauntSkill.selfEffect && tauntSkill.selfEffect.modifiers.stat === 'physicalDefense', '도발 스킬은 방어력 증가 효과를 가져야 합니다.');
+assert.strictEqual(tauntSkill.damageMultiplier, 0, '도발 스킬은 데미지를 주지 않아야 합니다.');
 
 const shieldBashSkill = activeSkills.shieldBash.NORMAL;
 assert(shieldBashSkill && shieldBashSkill.range === 1, '방패 치기 스킬의 사거리는 1이어야 합니다.');


### PR DESCRIPTION
## Summary
- prevent shadow step from harming its caster by making it a buff skill
- ensure taunt applies no damage by setting its multiplier to zero
- limit commander mercenary's attack range to two tiles
- add regression tests for shadow step, taunt, and commander stats

## Testing
- `for f in tests/*test.js; do echo "Running $f"; node $f > /tmp/test.log && tail -n 20 /tmp/test.log; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a072bdd1fc832781739f675d927489