### PR TITLE
Add MBTI compatibility matrix data module

### DIFF
--- a/src/game/data/mbtiCompatibility.js
+++ b/src/game/data/mbtiCompatibility.js
@@ -1,0 +1,22 @@
+export const MBTI_TYPES = [
+  'INTJ','INTP','ENTJ','ENTP',
+  'INFJ','INFP','ENFJ','ENFP',
+  'ISTJ','ISFJ','ESTJ','ESFJ',
+  'ISTP','ISFP','ESTP','ESFP'
+];
+
+// 각 MBTI 조합의 궁합 점수를 0~4 범위로 나타낸 매트릭스.
+// 동일한 글자를 공유할 때마다 1점을 부여합니다.
+export const MBTI_COMPATIBILITY_MATRIX = MBTI_TYPES.reduce((matrix, typeA) => {
+  matrix[typeA] = {};
+  MBTI_TYPES.forEach(typeB => {
+    const score = [...typeA].reduce((acc, ch, idx) => acc + (ch === typeB[idx] ? 1 : 0), 0);
+    matrix[typeA][typeB] = score;
+  });
+  return matrix;
+}, {});
+
+// 두 MBTI 간의 궁합 점수를 반환합니다.
+export function getMbtiCompatibility(typeA, typeB) {
+  return MBTI_COMPATIBILITY_MATRIX[typeA]?.[typeB] ?? 0;
+}

--- a/tests/mbti_compatibility_test.js
+++ b/tests/mbti_compatibility_test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import { MBTI_COMPATIBILITY_MATRIX, getMbtiCompatibility } from '../src/game/data/mbtiCompatibility.js';
+
+console.log('--- MBTI 궁합 매트릭스 테스트 시작 ---');
+
+assert.strictEqual(getMbtiCompatibility('INTJ', 'INTJ'), 4);
+assert.strictEqual(getMbtiCompatibility('INTJ', 'ENTJ'), 3);
+assert.strictEqual(
+  MBTI_COMPATIBILITY_MATRIX['INTJ']['ENTJ'],
+  getMbtiCompatibility('ENTJ', 'INTJ')
+);
+
+console.log('MBTI 궁합 매트릭스 테스트 성공');


### PR DESCRIPTION
## Summary
- add MBTI compatibility matrix and accessor
- cover compatibility logic with a small test

## Testing
- `for f in tests/*_test.js; do node "$f"; done >/tmp/all_tests.log && tail -n 20 /tmp/all_tests.log`
- `node tests/mbti_compatibility_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68aa0a5b2bec8327b3d12736b8e982b3