### PR TITLE
Add MBTI-based revenge attack mechanic

### DIFF
--- a/src/game/data/mbtiCompatibility.js
+++ b/src/game/data/mbtiCompatibility.js
@@ -1,0 +1,22 @@
+export const MBTI_TYPES = [
+  'INTJ','INTP','ENTJ','ENTP',
+  'INFJ','INFP','ENFJ','ENFP',
+  'ISTJ','ISFJ','ESTJ','ESFJ',
+  'ISTP','ISFP','ESTP','ESFP'
+];
+
+// 각 MBTI 조합의 궁합 점수를 0~4 범위로 나타낸 매트릭스.
+// 동일한 글자를 공유할 때마다 1점을 부여합니다.
+export const MBTI_COMPATIBILITY_MATRIX = MBTI_TYPES.reduce((matrix, typeA) => {
+  matrix[typeA] = {};
+  MBTI_TYPES.forEach(typeB => {
+    const score = [...typeA].reduce((acc, ch, idx) => acc + (ch === typeB[idx] ? 1 : 0), 0);
+    matrix[typeA][typeB] = score;
+  });
+  return matrix;
+}, {});
+
+// 두 MBTI 간의 궁합 점수를 반환합니다.
+export function getMbtiCompatibility(typeA, typeB) {
+  return MBTI_COMPATIBILITY_MATRIX[typeA]?.[typeB] ?? 0;
+}

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -38,6 +38,7 @@ import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 import { EFFECT_TYPES } from './EffectTypes.js';
 import { BattleSpeedManager } from './BattleSpeedManager.js';
 import { NarrationUIManager } from '../dom/NarrationUIManager.js';
+import { mbtiRevengeEngine } from './MBTIRevengeEngine.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -100,6 +101,7 @@ export class BattleSimulatorEngine {
         aspirationEngine.setBattleSimulator(this);
         // ✨ CombatCalculationEngine에 battleSimulator 참조 설정
         combatCalculationEngine.setBattleSimulator(this);
+        mbtiRevengeEngine.setBattleSimulator(this);
 
         this.turnQueue = [];
         this.currentTurnIndex = 0;

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -1,0 +1,50 @@
+import { getMbtiCompatibility } from '../data/mbtiCompatibility.js';
+import { aspirationEngine } from './AspirationEngine.js';
+import { combatCalculationEngine } from './CombatCalculationEngine.js';
+
+class MBTIRevengeEngine {
+  constructor() {
+    this.name = 'MBTIRevengeEngine';
+    this.battleSimulator = null;
+  }
+
+  setBattleSimulator(simulator) {
+    this.battleSimulator = simulator;
+  }
+
+  _getMBTIString(unit) {
+    const m = unit.mbti;
+    if (!m) return null;
+    return (m.E > m.I ? 'E' : 'I') +
+           (m.S > m.N ? 'S' : 'N') +
+           (m.T > m.F ? 'T' : 'F') +
+           (m.J > m.P ? 'J' : 'P');
+  }
+
+  handleAttack(attacker, defender, skill) {
+    if (!this.battleSimulator || !attacker || !defender) return;
+    if (!skill || skill.type !== 'ACTIVE') return;
+    const defenderType = this._getMBTIString(defender);
+    if (!defenderType) return;
+
+    const allies = this.battleSimulator.turnQueue.filter(u => u.team === defender.team && u.currentHp > 0);
+    allies.forEach(ally => {
+      if (ally === defender) return;
+      const allyType = this._getMBTIString(ally);
+      if (!allyType) return;
+      if (getMbtiCompatibility(allyType, defenderType) < 3) return;
+
+      const distance = Math.abs(ally.gridX - attacker.gridX) + Math.abs(ally.gridY - attacker.gridY);
+      const range = ally.finalStats?.attackRange || 1;
+      const aspiration = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
+      if (distance <= range && aspiration >= 10) {
+        aspirationEngine.addAspiration(ally.uniqueId, -10, '리벤지 어택');
+        const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 1 };
+        const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, attacker, revengeSkill);
+        this.battleSimulator.skillEffectProcessor._applyDamage(attacker, damage, hitType);
+      }
+    });
+  }
+}
+
+export const mbtiRevengeEngine = new MBTIRevengeEngine();

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -23,6 +23,7 @@ import { statusEffects } from '../data/status-effects.js';
 import { cooldownManager } from './CooldownManager.js'; // 쿨다운 매니저 import 추가
 import { aspirationEngine } from './AspirationEngine.js';
 import { trapManager } from './TrapManager.js';
+import { mbtiRevengeEngine } from './MBTIRevengeEngine.js';
 
 /**
  * 스킬의 실제 효과(데미지, 치유, 상태이상 등)를 게임 세계에 적용하는 것을 전담하는 엔진
@@ -370,6 +371,7 @@ class SkillEffectProcessor {
                     // 버프가 없으면 일반 피해 적용
                     hpDamage = this._applyDamage(currentTarget, totalDamage, hitType);
                 }
+                mbtiRevengeEngine.handleAttack(unit, currentTarget, finalSkillData);
                 if (skill.lifeSteal && hpDamage > 0) {
                     const healAmount = Math.round(hpDamage * skill.lifeSteal);
                     unit.currentHp = Math.min(unit.finalStats.hp, unit.currentHp + healAmount);

--- a/tests/mbti_compatibility_test.js
+++ b/tests/mbti_compatibility_test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import { MBTI_COMPATIBILITY_MATRIX, getMbtiCompatibility } from '../src/game/data/mbtiCompatibility.js';
+
+console.log('--- MBTI 궁합 매트릭스 테스트 시작 ---');
+
+assert.strictEqual(getMbtiCompatibility('INTJ', 'INTJ'), 4);
+assert.strictEqual(getMbtiCompatibility('INTJ', 'ENTJ'), 3);
+assert.strictEqual(
+  MBTI_COMPATIBILITY_MATRIX['INTJ']['ENTJ'],
+  getMbtiCompatibility('ENTJ', 'INTJ')
+);
+
+console.log('MBTI 궁합 매트릭스 테스트 성공');

--- a/tests/mbti_revenge_engine_test.js
+++ b/tests/mbti_revenge_engine_test.js
@@ -1,0 +1,66 @@
+import './setup-indexeddb.js';
+import assert from 'assert';
+import { mbtiRevengeEngine } from '../src/game/utils/MBTIRevengeEngine.js';
+import { aspirationEngine } from '../src/game/utils/AspirationEngine.js';
+import { combatCalculationEngine } from '../src/game/utils/CombatCalculationEngine.js';
+import { mbtiFromString } from '../src/game/data/classMbtiMap.js';
+
+console.log('--- MBTI Revenge Engine Test ---');
+
+// Create units
+const defender = {
+  uniqueId: 1,
+  team: 'ally',
+  mbti: mbtiFromString('INTJ'),
+  finalStats: { hp: 100, physicalDefense: 0 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 0,
+  gridY: 0,
+};
+
+const ally = {
+  uniqueId: 2,
+  team: 'ally',
+  mbti: mbtiFromString('INTJ'),
+  finalStats: { hp: 100, physicalAttack: 30, physicalDefense: 0, attackRange: 1 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 1,
+  gridY: 0,
+};
+
+const attacker = {
+  uniqueId: 3,
+  team: 'enemy',
+  mbti: mbtiFromString('ENTP'),
+  finalStats: { hp: 100, physicalDefense: 0 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 1,
+  gridY: 1,
+};
+
+// Battle simulator stub
+const battleSimulator = {
+  turnQueue: [defender, ally, attacker],
+  skillEffectProcessor: {
+    _applyDamage(target, damage) {
+      target.currentHp -= damage;
+    }
+  }
+};
+
+mbtiRevengeEngine.setBattleSimulator(battleSimulator);
+combatCalculationEngine.setBattleSimulator(battleSimulator);
+aspirationEngine.setBattleSimulator(battleSimulator);
+aspirationEngine.initializeUnits([defender, ally, attacker]);
+
+const beforeAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
+mbtiRevengeEngine.handleAttack(attacker, defender, { type: 'ACTIVE' });
+const afterAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
+
+assert.strictEqual(afterAsp, beforeAsp - 10, 'Aspiration should decrease by 10');
+assert(attacker.currentHp < 100, 'Attacker should take damage');
+
+console.log('MBTI Revenge Engine test passed');


### PR DESCRIPTION
## Summary
- add MBTIRevengeEngine to trigger retaliation when allies with compatible MBTI are attacked
- wire revenge engine into battle simulator and skill effect processing
- cover revenge logic with a focused unit test

## Testing
- `for f in tests/*_test.js; do node "$f"; done >/tmp/all_tests.log && tail -n 20 /tmp/all_tests.log`
- `node tests/mbti_revenge_engine_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa0a5b2bec8327b3d12736b8e982b3