### PR TITLE
feat: show MBTI combo attack notices

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1939,3 +1939,26 @@ body {
     font-style: italic;
     text-shadow: 1px 1px 2px #000;
 }
+
+#battle-notice-container {
+    position: absolute;
+    top: 50%;
+    right: 20px;
+    transform: translateY(-50%);
+    background-color: rgba(0, 0, 0, 0.6);
+    border-left: 2px solid #666;
+    border-radius: 8px 0 0 8px;
+    padding: 8px 12px;
+    z-index: 199;
+    pointer-events: none;
+    transition: opacity 0.5s ease-in-out;
+    text-align: center;
+}
+
+.battle-notice-text {
+    margin: 0;
+    color: #93c5fd;
+    font-size: 18px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+}

--- a/src/game/dom/BattleNoticeUIManager.js
+++ b/src/game/dom/BattleNoticeUIManager.js
@@ -1,0 +1,51 @@
+/**
+ * Displays brief combat notifications on the right side of the screen.
+ */
+export class BattleNoticeUIManager {
+    constructor() {
+        this.container = document.getElementById('battle-notice-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'battle-notice-container';
+            document.getElementById('ui-container').appendChild(this.container);
+        }
+        this.noticeText = document.createElement('p');
+        this.noticeText.className = 'battle-notice-text';
+        this.container.appendChild(this.noticeText);
+        this.container.style.display = 'none';
+        this.timeoutId = null;
+    }
+
+    /**
+     * Show a message briefly.
+     * @param {string} message
+     * @param {number} duration
+     */
+    show(message, duration = 1500) {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+        this.noticeText.textContent = message;
+        this.container.style.display = 'block';
+        this.container.style.opacity = 1;
+        this.timeoutId = setTimeout(() => {
+            this.container.style.opacity = 0;
+            setTimeout(() => {
+                this.container.style.display = 'none';
+            }, 500);
+        }, duration);
+    }
+
+    hide() {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+        this.container.style.display = 'none';
+    }
+
+    destroy() {
+        this.hide();
+        this.container.remove();
+        this.container = null;
+    }
+}

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -39,6 +39,8 @@ import { EFFECT_TYPES } from './EffectTypes.js';
 import { BattleSpeedManager } from './BattleSpeedManager.js';
 import { NarrationUIManager } from '../dom/NarrationUIManager.js';
 import { mbtiRevengeEngine } from './MBTIRevengeEngine.js';
+import { mbtiChainAttackEngine } from './MBTIChainAttackEngine.js';
+import { BattleNoticeUIManager } from '../dom/BattleNoticeUIManager.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -77,6 +79,7 @@ export class BattleSimulatorEngine {
         this.turnOrderUI = new TurnOrderUIManager();
         this.sharedResourceUI = new SharedResourceUIManager();
         this.narrationUI = new NarrationUIManager();
+        this.noticeUI = new BattleNoticeUIManager();
         
         // AI 노드에 주입할 엔진 패키지
         this.aiEngines = {
@@ -102,6 +105,7 @@ export class BattleSimulatorEngine {
         // ✨ CombatCalculationEngine에 battleSimulator 참조 설정
         combatCalculationEngine.setBattleSimulator(this);
         mbtiRevengeEngine.setBattleSimulator(this);
+        mbtiChainAttackEngine.setBattleSimulator(this);
 
         this.turnQueue = [];
         this.currentTurnIndex = 0;

--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -35,6 +35,7 @@ class MBTIChainAttackEngine {
         const chainSkill = { id: 'mbtiChain', name: '체인 어택', type: 'ACTIVE', damageMultiplier: 1 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, defender, chainSkill);
         this.battleSimulator.skillEffectProcessor._applyDamage(defender, damage, hitType);
+        this.battleSimulator.noticeUI?.show('Chain Attack!');
       }
     });
   }

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -35,6 +35,7 @@ class MBTIRevengeEngine {
         const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 1 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, attacker, revengeSkill);
         this.battleSimulator.skillEffectProcessor._applyDamage(attacker, damage, hitType);
+        this.battleSimulator.noticeUI?.show('Revenge Attack!');
       }
     });
   }

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -24,6 +24,7 @@ import { cooldownManager } from './CooldownManager.js'; // 쿨다운 매니저 i
 import { aspirationEngine } from './AspirationEngine.js';
 import { trapManager } from './TrapManager.js';
 import { mbtiRevengeEngine } from './MBTIRevengeEngine.js';
+import { mbtiChainAttackEngine } from './MBTIChainAttackEngine.js';
 
 /**
  * 스킬의 실제 효과(데미지, 치유, 상태이상 등)를 게임 세계에 적용하는 것을 전담하는 엔진
@@ -371,6 +372,7 @@ class SkillEffectProcessor {
                     // 버프가 없으면 일반 피해 적용
                     hpDamage = this._applyDamage(currentTarget, totalDamage, hitType);
                 }
+                mbtiChainAttackEngine.handleAttack(unit, currentTarget, finalSkillData);
                 mbtiRevengeEngine.handleAttack(unit, currentTarget, finalSkillData);
                 if (skill.lifeSteal && hpDamage > 0) {
                     const healAmount = Math.round(hpDamage * skill.lifeSteal);


### PR DESCRIPTION
## Summary
- add BattleNoticeUIManager for right-side combat popups
- display Chain Attack and Revenge Attack notifications
- integrate MBTI chain engine into battle flow

## Testing
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `node tests/mbti_compatibility_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa11ce2aa08327b876396b423fcb2f