### PR TITLE
feat: animate chain and revenge attacks

### DIFF
--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -2,6 +2,7 @@ import { getMbtiCompatibility } from '../data/mbtiCompatibility.js';
 import { aspirationEngine } from './AspirationEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
+import { spriteEngine } from './SpriteEngine.js';
 
 class MBTIChainAttackEngine {
   constructor() {
@@ -34,6 +35,12 @@ class MBTIChainAttackEngine {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '체인 어택');
         const chainSkill = { id: 'mbtiChain', name: '체인 어택', type: 'ACTIVE', damageMultiplier: 1 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, defender, chainSkill);
+
+        if (ally.sprite && defender.sprite) {
+          spriteEngine.changeSpriteForDuration(ally, 'attack', 600);
+          this.battleSimulator.animationEngine?.attack(ally.sprite, defender.sprite);
+        }
+
         this.battleSimulator.skillEffectProcessor._applyDamage(defender, damage, hitType);
         this.battleSimulator.noticeUI?.show('Chain Attack!');
       }

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -2,6 +2,7 @@ import { getMbtiCompatibility } from '../data/mbtiCompatibility.js';
 import { aspirationEngine } from './AspirationEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
+import { spriteEngine } from './SpriteEngine.js';
 
 class MBTIRevengeEngine {
   constructor() {
@@ -34,6 +35,12 @@ class MBTIRevengeEngine {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '리벤지 어택');
         const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 1 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, attacker, revengeSkill);
+
+        if (ally.sprite && attacker.sprite) {
+          spriteEngine.changeSpriteForDuration(ally, 'attack', 600);
+          this.battleSimulator.animationEngine?.attack(ally.sprite, attacker.sprite);
+        }
+
         this.battleSimulator.skillEffectProcessor._applyDamage(attacker, damage, hitType);
         this.battleSimulator.noticeUI?.show('Revenge Attack!');
       }

--- a/tests/mbti_chain_attack_engine_test.js
+++ b/tests/mbti_chain_attack_engine_test.js
@@ -28,6 +28,7 @@ const ally = {
   currentBarrier: 0,
   gridX: 1,
   gridY: 0,
+  sprite: { x: 1, y: 0 },
 };
 
 const defender = {
@@ -39,11 +40,18 @@ const defender = {
   currentBarrier: 0,
   gridX: 1,
   gridY: 1,
+  sprite: { x: 1, y: 1 },
 };
 
 // Battle simulator stub
+let animationCalled = false;
 const battleSimulator = {
   turnQueue: [attacker, ally, defender],
+  animationEngine: {
+    attack() {
+      animationCalled = true;
+    }
+  },
   skillEffectProcessor: {
     _applyDamage(target, damage) {
       target.currentHp -= damage;
@@ -62,5 +70,6 @@ const afterAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
 
 assert.strictEqual(afterAsp, beforeAsp - 10, 'Aspiration should decrease by 10');
 assert(defender.currentHp < 100, 'Defender should take damage');
+assert(animationCalled, 'Animation should trigger');
 
 console.log('MBTI Chain Attack Engine test passed');

--- a/tests/mbti_revenge_engine_test.js
+++ b/tests/mbti_revenge_engine_test.js
@@ -17,6 +17,7 @@ const defender = {
   currentBarrier: 0,
   gridX: 0,
   gridY: 0,
+  sprite: { x: 0, y: 0 },
 };
 
 const ally = {
@@ -28,6 +29,7 @@ const ally = {
   currentBarrier: 0,
   gridX: 1,
   gridY: 0,
+  sprite: { x: 1, y: 0 },
 };
 
 const attacker = {
@@ -39,11 +41,18 @@ const attacker = {
   currentBarrier: 0,
   gridX: 1,
   gridY: 1,
+  sprite: { x: 1, y: 1 },
 };
 
 // Battle simulator stub
+let animationCalled = false;
 const battleSimulator = {
   turnQueue: [defender, ally, attacker],
+  animationEngine: {
+    attack() {
+      animationCalled = true;
+    }
+  },
   skillEffectProcessor: {
     _applyDamage(target, damage) {
       target.currentHp -= damage;
@@ -62,5 +71,6 @@ const afterAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
 
 assert.strictEqual(afterAsp, beforeAsp - 10, 'Aspiration should decrease by 10');
 assert(attacker.currentHp < 100, 'Attacker should take damage');
+assert(animationCalled, 'Animation should trigger');
 
 console.log('MBTI Revenge Engine test passed');


### PR DESCRIPTION
## Summary
- trigger attack animation when MBTI chain attack and revenge attack fire
- test engines to confirm animation calls

## Testing
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa144bb8788327941a20b4f2e1f78b