### PR TITLE
Remove exalted state and tweak aspiration mechanics

### DIFF
--- a/src/game/utils/AspirationEngine.js
+++ b/src/game/utils/AspirationEngine.js
@@ -56,16 +56,7 @@ class AspirationEngine {
             debugAspirationManager.logAspirationChange(unitId, unitName, oldAspiration, newAspiration, amount, reason);
         }
 
-        // 상태 변화 체크
-        if (data.aspiration >= 100) {
-            data.state = ASPIRATION_STATE.EXALTED;
-            const unit = this.battleSimulator.turnQueue.find(u => u.uniqueId === unitId);
-            if (unit) {
-                this._applyExaltedBuffs(unit);
-                debugAspirationManager.logStateChange(unit.instanceName, ASPIRATION_STATE.EXALTED);
-            }
-        }
-        // ✨ [수정] 열망 붕괴 로직을 삭제했습니다.
+        // 더 이상 특정 수치 도달에 따른 상태 변화는 발생하지 않습니다.
     }
 
     _applyExaltedBuffs(unit) {

--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -33,7 +33,7 @@ class MBTIChainAttackEngine {
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '체인 어택');
-        const chainSkill = { id: 'mbtiChain', name: '체인 어택', type: 'ACTIVE', damageMultiplier: 1 };
+        const chainSkill = { id: 'mbtiChain', name: '체인 어택', type: 'ACTIVE', damageMultiplier: 0.5 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, defender, chainSkill);
 
         if (ally.sprite && defender.sprite) {

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -33,7 +33,7 @@ class MBTIRevengeEngine {
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '리벤지 어택');
-        const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 1 };
+        const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 0.5 };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, attacker, revengeSkill);
 
         if (ally.sprite && attacker.sprite) {

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -471,6 +471,11 @@ class SkillEffectProcessor {
             this.vfxManager.createDamageNumber(unit.sprite.x, unit.sprite.y - 10, `+${healAmount}`, '#ffd700', '배리어');
         }
 
+        // 적에게 피해를 준 공격 스킬 사용 시 열망 5 상승
+        if (finalTargets.length > 0) {
+            aspirationEngine.addAspiration(unit.uniqueId, 5, '공격 스킬 사용');
+        }
+
     }
 
     // --- [신규] 피해 적용 로직을 별도 메서드로 추출 ---


### PR DESCRIPTION
## Summary
- Remove EXALTED trigger when aspiration reaches 100
- Raise user aspiration by 5 on damage-dealing skill use
- Halve damage multipliers for chain and revenge attacks

## Testing
- `for f in tests/*_test.js; do echo Running $f; node $f; done`
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa15ac79d88327955e47a84422664b