### PR TITLE
Fix commander skill range handling and MBTI status damage triggers

### DIFF
--- a/src/ai/nodes/FindLowestHealthAllyNode.js
+++ b/src/ai/nodes/FindLowestHealthAllyNode.js
@@ -29,7 +29,7 @@ class FindLowestHealthAllyNode extends Node {
 
         let potentialTargets = allies;
         if (this.inRangeOnly) {
-            const healRange = blackboard.get('currentSkillData')?.range || 2;
+            const healRange = blackboard.get('currentSkillData')?.range ?? 2;
             potentialTargets = allies.filter(a => {
                 const dist = Math.abs(unit.gridX - a.gridX) + Math.abs(unit.gridY - a.gridY);
                 return dist <= healRange;

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -17,7 +17,7 @@ class FindSafeHealingPositionNode extends Node {
         debugAIManager.logNodeEvaluation(this, unit);
         const targetAlly = blackboard.get('skillTarget');
         const enemies = blackboard.get('enemyUnits');
-        const healRange = blackboard.get('currentSkillData')?.range || 2;
+        const healRange = blackboard.get('currentSkillData')?.range ?? 2;
 
         if (!targetAlly) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '치유 대상 아군 없음');

--- a/src/ai/utils/findBestActionForUnit.js
+++ b/src/ai/utils/findBestActionForUnit.js
@@ -56,7 +56,7 @@ export async function findBestActionForUnit(unit, allies = [], enemies = [], use
                 if (isSelfTarget) return t.uniqueId === virtualUnit.uniqueId;
                 if (t.uniqueId === virtualUnit.uniqueId) return false;
                 const dist = Math.abs(t.gridX - virtualUnit.gridX) + Math.abs(t.gridY - virtualUnit.gridY);
-                return dist <= (skillData.range || 1);
+                return dist <= (skillData.range ?? 1);
             });
 
             for (const target of targets) {

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -506,6 +506,14 @@ class SkillEffectProcessor {
         return damageToHp;
     }
 
+    applyStatusEffectDamage(attacker, target, damage, damageType) {
+        const hpDamage = this._applyDamage(target, damage, damageType, '#9333ea');
+        if (target.currentHp <= 0) {
+            this.terminationManager.handleUnitDeath(target, attacker);
+        }
+        return hpDamage;
+    }
+
     async _processAidSkill(unit, target, skill) {
         spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
 

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -102,13 +102,8 @@ class StatusEffectManager {
                     // ✨ --- 추가 완료 --- ✨
 
                     if (damage > 0) {
-                        unit.currentHp -= damage;
-                        if (this.battleSimulator.vfxManager) {
-                            this.battleSimulator.vfxManager.createDamageNumber(unit.sprite.x, unit.sprite.y, damage, '#9333ea', damageType);
-                        }
-                        if (unit.currentHp <= 0) {
-                            this.battleSimulator.terminationManager.handleUnitDeath(unit);
-                        }
+                        const caster = effect.attackerId ? this.findUnitById(effect.attackerId) : null;
+                        this.battleSimulator.skillEffectProcessor.applyStatusEffectDamage(caster, unit, damage, damageType);
                     }
                 });
 

--- a/tests/mbti_status_effect_trigger_test.js
+++ b/tests/mbti_status_effect_trigger_test.js
@@ -1,0 +1,106 @@
+import './setup-indexeddb.js';
+import assert from 'assert';
+import { statusEffectManager } from '../src/game/utils/StatusEffectManager.js';
+import { mbtiChainAttackEngine } from '../src/game/utils/MBTIChainAttackEngine.js';
+import { mbtiRevengeEngine } from '../src/game/utils/MBTIRevengeEngine.js';
+import { aspirationEngine } from '../src/game/utils/AspirationEngine.js';
+import { mbtiFromString } from '../src/game/data/classMbtiMap.js';
+import { EFFECT_TYPES } from '../src/game/utils/EffectTypes.js';
+
+console.log('--- MBTI Status Effect Trigger Test ---');
+
+const attacker = {
+  uniqueId: 1,
+  team: 'ally',
+  mbti: mbtiFromString('INTJ'),
+  finalStats: { hp: 100, physicalAttack: 30, attackRange: 1 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 0,
+  gridY: 0,
+  sprite: { x: 0, y: 0 }
+};
+
+const chainAlly = {
+  uniqueId: 2,
+  team: 'ally',
+  mbti: mbtiFromString('INTJ'),
+  finalStats: { hp: 100, attackRange: 1, physicalAttack: 30 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 1,
+  gridY: 0,
+  sprite: { x: 1, y: 0 }
+};
+
+const defender = {
+  uniqueId: 3,
+  team: 'enemy',
+  mbti: mbtiFromString('ENTP'),
+  finalStats: { hp: 100, physicalDefense: 0 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 1,
+  gridY: 1,
+  sprite: { x: 1, y: 1 }
+};
+
+const revengeAlly = {
+  uniqueId: 4,
+  team: 'enemy',
+  mbti: mbtiFromString('ENTP'),
+  finalStats: { hp: 100, attackRange: 1, physicalAttack: 30 },
+  currentHp: 100,
+  currentBarrier: 0,
+  gridX: 0,
+  gridY: 1,
+  sprite: { x: 0, y: 1 }
+};
+
+let chainTriggered = false;
+let revengeTriggered = false;
+
+const battleSimulator = {
+  turnQueue: [attacker, chainAlly, defender, revengeAlly],
+  animationEngine: {
+    attack(attackSprite) {
+      if (attackSprite === chainAlly.sprite) chainTriggered = true;
+      if (attackSprite === revengeAlly.sprite) revengeTriggered = true;
+    }
+  },
+  skillEffectProcessor: {
+    _applyDamage(target, damage) { target.currentHp -= damage; },
+    applyStatusEffectDamage(attacker, target, damage) {
+      this._applyDamage(target, damage);
+    }
+  },
+  terminationManager: { handleUnitDeath() {} },
+  vfxManager: { createDamageNumber() {}, showEffectName() {} },
+  noticeUI: { show() {} }
+};
+
+statusEffectManager.setBattleSimulator(battleSimulator);
+mbtiChainAttackEngine.setBattleSimulator(battleSimulator);
+mbtiRevengeEngine.setBattleSimulator(battleSimulator);
+aspirationEngine.setBattleSimulator(battleSimulator);
+aspirationEngine.initializeUnits(battleSimulator.turnQueue);
+
+aspirationEngine.addAspiration(chainAlly.uniqueId, 20, 'init');
+aspirationEngine.addAspiration(revengeAlly.uniqueId, 20, 'init');
+
+const beforeChainAsp = aspirationEngine.getAspirationData(chainAlly.uniqueId).aspiration;
+const beforeRevengeAsp = aspirationEngine.getAspirationData(revengeAlly.uniqueId).aspiration;
+
+statusEffectManager.addEffect(defender, { name: 'Burn', effect: { id: 'burn', type: EFFECT_TYPES.DEBUFF, duration: 1 } }, attacker);
+
+statusEffectManager.onTurnEnd(battleSimulator.turnQueue);
+
+const chainAsp = aspirationEngine.getAspirationData(chainAlly.uniqueId).aspiration;
+const revengeAsp = aspirationEngine.getAspirationData(revengeAlly.uniqueId).aspiration;
+
+assert.strictEqual(chainTriggered, false, 'Chain attack should not trigger from status effect damage');
+assert.strictEqual(revengeTriggered, false, 'Revenge attack should not trigger from status effect damage');
+assert.strictEqual(chainAsp, beforeChainAsp, 'Chain ally aspiration should remain unchanged');
+assert.strictEqual(revengeAsp, beforeRevengeAsp, 'Revenge ally aspiration should remain unchanged');
+
+console.log('MBTI status effect trigger test passed');


### PR DESCRIPTION
## Summary
- ensure skill range checks respect zero-range abilities
- prevent status-effect damage from triggering MBTI chain or revenge attacks
- add regression test for MBTI reactions to status damage

## Testing
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `node tests/status_effect_interaction_test.js`
- `node tests/mbti_status_effect_trigger_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa1974442883278a6ec06e3e48e094