### PR TITLE
feat: add chain and revenge debug manager

### DIFF
--- a/src/game/debug/DebugChainRevengeManager.js
+++ b/src/game/debug/DebugChainRevengeManager.js
@@ -1,0 +1,29 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugChainRevengeManager {
+    constructor() {
+        this.name = 'DebugChainRevenge';
+        debugLogEngine.register(this);
+    }
+
+    logChainAttack(ally, attacker, defender, damage, hitType) {
+        console.groupCollapsed(`%c[${this.name}]`, `color: #16a34a; font-weight: bold;`, '체인 어택 발동');
+        debugLogEngine.log(
+            this.name,
+            `동료 ${ally.uniqueId}가 공격자 ${attacker.uniqueId}의 체인 어택을 지원하여 대상 ${defender.uniqueId}에게 ` +
+            `${damage} 피해를 가했습니다. (히트: ${hitType})`
+        );
+        console.groupEnd();
+    }
+
+    logRevengeAttack(ally, attacker, defender, damage, hitType) {
+        console.groupCollapsed(`%c[${this.name}]`, `color: #dc2626; font-weight: bold;`, '리벤지 어택 발동');
+        debugLogEngine.log(
+            this.name,
+            `동료 ${ally.uniqueId}가 공격자 ${attacker.uniqueId}에게 복수하여 대상 ${defender.uniqueId}에게 ${damage} 피해를 가했습니다. (히트: ${hitType})`
+        );
+        console.groupEnd();
+    }
+}
+
+export const debugChainRevengeManager = new DebugChainRevengeManager();

--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -3,6 +3,7 @@ import { aspirationEngine } from './AspirationEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
 import { spriteEngine } from './SpriteEngine.js';
+import { debugChainRevengeManager } from '../debug/DebugChainRevengeManager.js';
 
 class MBTIChainAttackEngine {
   constructor() {
@@ -43,6 +44,7 @@ class MBTIChainAttackEngine {
 
         this.battleSimulator.skillEffectProcessor._applyDamage(defender, damage, hitType);
         this.battleSimulator.noticeUI?.show('Chain Attack!');
+        debugChainRevengeManager.logChainAttack(ally, attacker, defender, damage, hitType);
       }
     });
   }

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -3,6 +3,7 @@ import { aspirationEngine } from './AspirationEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
 import { spriteEngine } from './SpriteEngine.js';
+import { debugChainRevengeManager } from '../debug/DebugChainRevengeManager.js';
 
 class MBTIRevengeEngine {
   constructor() {
@@ -43,6 +44,7 @@ class MBTIRevengeEngine {
 
         this.battleSimulator.skillEffectProcessor._applyDamage(attacker, damage, hitType);
         this.battleSimulator.noticeUI?.show('Revenge Attack!');
+        debugChainRevengeManager.logRevengeAttack(ally, attacker, defender, damage, hitType);
       }
     });
   }


### PR DESCRIPTION
## Summary
- add DebugChainRevengeManager to log chain and revenge attacks
- hook chain and revenge engines to record detailed attack info

## Testing
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `node tests/mbti_status_effect_trigger_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68aa1d3bd17883279675f08a0cb65bcb