### PR TITLE
Improve pathfinding checks

### DIFF
--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -181,9 +181,18 @@ class PathfinderEngine {
 
         const reachable = [];
         for (const tile of candidateTiles) {
+            // 이동력이 부족한 타일은 탐색하지 않습니다.
+            const heuristic = Math.abs(start.col - tile.col) + Math.abs(start.row - tile.row);
+            if (heuristic > moveRange) {
+                continue;
+            }
+
             const path = await this.findPath(unit, start, tile);
-            if (Array.isArray(path) && path.length <= moveRange) {
-                reachable.push({ path });
+
+            if (Array.isArray(path)) {
+                if (path.length <= moveRange) {
+                    reachable.push({ path });
+                }
             } else if (path) {
                 debugLogEngine.warn('PathfinderEngine', 'findPath가 배열이 아닌 값을 반환했습니다.', { tile, path });
             }


### PR DESCRIPTION
## Summary
- Skip pathfinding attempts for tiles beyond a unit's movement
- Avoid false "non-array path" warnings when path length exceeds movement

## Testing
- `node tests/pathfinder_flyingmen_bug_test.js`
- `node tests/find_path_to_target_node_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68aa2211c16083279879045bb4261aac