### PR TITLE
fix: respect zero attack range in AI and tooltips

### DIFF
--- a/src/ai/nodes/FindEnemyAttackingAllyNode.js
+++ b/src/ai/nodes/FindEnemyAttackingAllyNode.js
@@ -19,7 +19,7 @@ class FindEnemyAttackingAllyNode extends Node {
         let target = null;
         let minDist = Infinity;
         for (const enemy of enemies) {
-            const range = enemy.finalStats.attackRange || 1;
+            const range = enemy.finalStats.attackRange ?? 1;
             const dist = Math.abs(enemy.gridX - ally.gridX) + Math.abs(enemy.gridY - ally.gridY);
             if (dist <= range && dist < minDist) {
                 target = enemy;

--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -30,7 +30,7 @@ class FindKitingPositionNode extends Node {
             this.narrationEngine.show(`${unit.instanceName}이(가) [${target.instanceName}]와(과) 거리를 벌리기 위해 이동합니다.`);
         }
 
-        const attackRange = unit.finalStats.attackRange || 3;
+        const attackRange = unit.finalStats.attackRange ?? 3;
         // ✨ 이 노드 자체의 dangerZone 하드코딩을 제거했습니다.
         // 이제 이 노드는 "안전한 공격 위치"를 찾는 데 집중하고,
         // "위험 여부" 판단은 IsTargetTooCloseNode가 전담합니다.

--- a/src/ai/nodes/FindMeleeStrategicTargetNode.js
+++ b/src/ai/nodes/FindMeleeStrategicTargetNode.js
@@ -12,7 +12,7 @@ class FindMeleeStrategicTargetNode extends Node {
 
     // 유닛을 공격할 수 있는 가장 가까운 위치로의 경로를 찾는 헬퍼 메서드
     async _findPathToUnit(unit, target) {
-        const attackRange = unit.finalStats.attackRange || 1;
+        const attackRange = unit.finalStats.attackRange ?? 1;
         const start = { col: unit.gridX, row: unit.gridY };
         const targetPos = { col: target.gridX, row: target.gridY };
 

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -40,7 +40,7 @@ class FindPathToTargetNode extends Node {
     }
 
     async _findPathToUnit(unit, target) {
-        const attackRange = unit.finalStats.attackRange || 1;
+        const attackRange = unit.finalStats.attackRange ?? 1;
         const start = { col: unit.gridX, row: unit.gridY };
         const targetPos = { col: target.gridX, row: target.gridY };
 

--- a/src/ai/nodes/FindPreferredTargetNode.js
+++ b/src/ai/nodes/FindPreferredTargetNode.js
@@ -17,7 +17,7 @@ class FindPreferredTargetNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const attackRange = unit.finalStats.attackRange || 1;
+        const attackRange = unit.finalStats.attackRange ?? 1;
         const inRange = enemyUnits.filter(e => e.currentHp > 0 &&
             Math.abs(unit.gridX - e.gridX) + Math.abs(unit.gridY - e.gridY) <= attackRange);
 

--- a/src/ai/nodes/IsTargetInRangeNode.js
+++ b/src/ai/nodes/IsTargetInRangeNode.js
@@ -10,7 +10,8 @@ class IsTargetInRangeNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const attackRange = unit.finalStats.attackRange || 1;
+        // null 병합 연산자를 사용해 0도 유효한 사거리로 인식합니다.
+        const attackRange = unit.finalStats.attackRange ?? 1;
         const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
 
         if (distance <= attackRange) {

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -34,8 +34,14 @@ export class SkillTooltipManager {
             }
         }
 
-        // 사거리 텍스트: 없으면 "기본 사거리"로 표시
-        const rangeText = skillData.range !== undefined ? `사거리 ${skillData.range}` : '기본 사거리';
+        // 사거리 텍스트를 계산합니다. 글로벌/오라 스킬은 특별 표기합니다.
+        const rangeText = skillData.effect?.isGlobal
+            ? '전장 전체'
+            : skillData.effect?.isAura
+                ? `오라 (반경 ${skillData.effect.radius ?? '?'} )`
+                : skillData.range !== undefined
+                    ? `사거리 ${skillData.range}`
+                    : '기본 사거리';
 
         tooltip.innerHTML = `
             <div class="skill-illustration-large" style="background-image: url(${placeholderManager.getPath(skillData.illustrationPath)})"></div>

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -156,10 +156,10 @@ class CombatCalculationEngine {
         }
         // ✨ [추가] 저격, 화염병 투척의 조건부 데미지 로직
         let bonusMultiplier = 1.0;
-        if (finalSkill.id === 'snipe' && (attacker.finalStats.attackRange || 1) >= 2) {
+        if (finalSkill.id === 'snipe' && (attacker.finalStats.attackRange ?? 1) >= 2) {
             bonusMultiplier += 0.20;
         }
-        if (finalSkill.id === 'fireBottle' && (attacker.finalStats.attackRange || 1) <= 1) {
+        if (finalSkill.id === 'fireBottle' && (attacker.finalStats.attackRange ?? 1) <= 1) {
             bonusMultiplier += 0.20;
         }
         // --- ▼ [1. '처형' 스킬 효과 로직 추가] ▼ ---

--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -29,7 +29,7 @@ class MBTIChainAttackEngine {
       if (getMbtiCompatibility(allyType, attackerType) < 3) return;
 
       const distance = Math.abs(ally.gridX - defender.gridX) + Math.abs(ally.gridY - defender.gridY);
-      const range = ally.finalStats?.attackRange || 1;
+      const range = ally.finalStats?.attackRange ?? 1;
       const aspirationData = aspirationEngine.getAspirationData(ally.uniqueId);
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -29,7 +29,7 @@ class MBTIRevengeEngine {
       if (getMbtiCompatibility(allyType, defenderType) < 3) return;
 
       const distance = Math.abs(ally.gridX - attacker.gridX) + Math.abs(ally.gridY - attacker.gridY);
-      const range = ally.finalStats?.attackRange || 1;
+      const range = ally.finalStats?.attackRange ?? 1;
       const aspirationData = aspirationEngine.getAspirationData(ally.uniqueId);
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {

--- a/tests/is_target_in_range_node_zero_test.js
+++ b/tests/is_target_in_range_node_zero_test.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import './setup-indexeddb.js';
+import IsTargetInRangeNode from '../src/ai/nodes/IsTargetInRangeNode.js';
+import Blackboard from '../src/ai/Blackboard.js';
+
+const node = new IsTargetInRangeNode();
+
+const unit = { gridX: 0, gridY: 0, finalStats: { attackRange: 0 }, instanceName: 'unit' };
+const target = { gridX: 0, gridY: 1, instanceName: 'target' };
+
+const blackboard = new Blackboard();
+blackboard.set('currentTargetUnit', target);
+
+const result = await node.evaluate(unit, blackboard);
+assert.strictEqual(result, 'FAILURE');
+console.log('✅ IsTargetInRangeNode zero range test passed');


### PR DESCRIPTION
## Summary
- handle 0 attack range correctly across AI nodes and MBTI engines
- show "전장 전체" or aura radius in skill tooltips
- add regression test for zero attack range handling

## Testing
- `for f in tests/*_test.js; do node $f || break; done`
- `node tests/is_target_in_range_node_zero_test.js`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aad978b4d083278a2b0062911e9635