### PR TITLE
feat: add commander debug manager

### DIFF
--- a/src/game/debug/DebugCommanderActionManager.js
+++ b/src/game/debug/DebugCommanderActionManager.js
@@ -1,0 +1,56 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 커맨더 클래스 유닛의 전투 행동을 추적하여 로그로 남기는 디버그 매니저
+ */
+class DebugCommanderActionManager {
+    constructor() {
+        this.name = 'DebugCommander';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 일반 행동을 로그로 출력합니다.
+     * @param {object} unit - 행동을 수행한 유닛
+     * @param {string} action - 수행한 행동 설명
+     * @param {string} [detail] - 추가 정보
+     */
+    logAction(unit, action, detail = '') {
+        if (unit.id !== 'commander') return;
+        const message = detail ? `${action} - ${detail}` : action;
+        debugLogEngine.log(this.name, `${unit.instanceName} 행동: ${message}`);
+    }
+
+    /**
+     * 스킬 사용 시 유닛과 타겟 간의 거리 정보를 포함한 로그를 출력합니다.
+     * @param {object} attacker - 스킬을 사용한 커맨더 유닛
+     * @param {object} target - 스킬 대상 유닛
+     * @param {object} skillData - 사용한 스킬 데이터
+     */
+    logSkillUse(attacker, target, skillData) {
+        if (attacker.id !== 'commander') return;
+
+        const atkName = attacker.instanceName || attacker.name || 'unknown';
+        const targetName = target?.instanceName || target?.name || 'unknown';
+
+        let distance = 'N/A';
+        if (
+            target &&
+            typeof attacker.gridX === 'number' && typeof attacker.gridY === 'number' &&
+            typeof target.gridX === 'number' && typeof target.gridY === 'number'
+        ) {
+            distance = Math.abs(attacker.gridX - target.gridX) + Math.abs(attacker.gridY - target.gridY);
+        }
+
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #6366f1; font-weight: bold;`,
+            `${atkName} -> ${targetName} 스킬 사용: ${skillData.name}`
+        );
+        debugLogEngine.log(this.name, `유닛 위치: (${attacker.gridX}, ${attacker.gridY})`);
+        debugLogEngine.log(this.name, `대상 위치: (${target?.gridX}, ${target?.gridY})`);
+        debugLogEngine.log(this.name, `거리: ${distance}`);
+        console.groupEnd();
+    }
+}
+
+export const debugCommanderActionManager = new DebugCommanderActionManager();

--- a/src/game/utils/BattleTagManager.js
+++ b/src/game/utils/BattleTagManager.js
@@ -1,4 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { debugCommanderActionManager } from '../debug/DebugCommanderActionManager.js';
 
 /**
  * 전투 중 발생하는 모든 스킬 태그를 감지하고 기록하는 중앙 매니저입니다.
@@ -30,6 +31,10 @@ class BattleTagManager {
         );
         debugLogEngine.log(this.name, `발생한 태그: %c${tagString}`, 'color: #facc15;');
         console.groupEnd();
+
+        if (attacker.id === 'commander') {
+            debugCommanderActionManager.logSkillUse(attacker, target, skillData);
+        }
 
         // 향후 이 곳에서 특정 태그에 반응하는 로직을 실행할 수 있습니다.
         // 예: eventEmitter.emit('skillTag', { attacker, target, skillData });

--- a/tests/commander_debug_manager_test.js
+++ b/tests/commander_debug_manager_test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { debugCommanderActionManager } from '../src/game/debug/DebugCommanderActionManager.js';
+
+debugCommanderActionManager; // ensure import is used
+
+const logs = [];
+const originalLog = console.log;
+const originalGroupCollapsed = console.groupCollapsed;
+const originalGroupEnd = console.groupEnd;
+
+console.log = (...args) => { logs.push(args.join(' ')); };
+console.groupCollapsed = (...args) => { logs.push(args.join(' ')); };
+console.groupEnd = () => {};
+
+debugCommanderActionManager.logSkillUse(
+    { id: 'commander', instanceName: 'Cmd', gridX: 0, gridY: 0 },
+    { instanceName: 'Target', gridX: 2, gridY: 3 },
+    { name: 'TestSkill' }
+);
+
+console.log = originalLog;
+console.groupCollapsed = originalGroupCollapsed;
+console.groupEnd = originalGroupEnd;
+
+assert(logs.some(line => line.includes('거리: 5')));
+console.log('✅ DebugCommanderActionManager distance calculation');


### PR DESCRIPTION
## Summary
- log commander unit actions with new DebugCommanderActionManager
- capture skill range details in BattleTagManager
- add test verifying commander debug distance calculation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/commander_debug_manager_test.js`
- `node tests/class_passive_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aafbe290f48327af9293ae517a9b62