### PR TITLE
fix: enforce skill range check

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -28,7 +28,7 @@ class AttackTargetNode extends Node {
             debugAIManager.logNodeResult(NodeState.FAILURE, '일반 공격을 위한 토큰 부족');
             return NodeState.FAILURE;
         }
-        skillEngine.recordSkillUse(unit, attackSkill);
+        skillEngine.recordSkillUse(unit, attackSkill, target);
 
         // 스킬 이름을 보여줍니다.
         const skillColor = SKILL_TYPES[attackSkill.type].color;

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -86,7 +86,7 @@ class UseSkillNode extends Node {
 
 
         // 스킬 사용 기록
-        this.skillEngine.recordSkillUse(unit, finalSkill);
+        this.skillEngine.recordSkillUse(unit, finalSkill, skillTarget);
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
         usedSkills.add(instanceId);
         blackboard.set('usedSkillsThisTurn', usedSkills);

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -460,7 +460,7 @@ export const battleSimulatorEngine = {
                     chosen = basicAttack;
                 }
 
-                skillEngine.recordSkillUse(unit, chosen);
+                skillEngine.recordSkillUse(unit, chosen, target);
                 const { damage } = combatCalculationEngine.calculateDamage(unit, target, chosen);
                 target.currentHp = Math.max(0, target.currentHp - damage);
 

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -89,9 +89,22 @@ class SkillEngine {
      * 용병이 스킬을 사용하는 것을 기록합니다.
      * @param {object} unit - 스킬을 사용한 유닛
      * @param {object} skill - 사용한 스킬 데이터
+     * @param {object|null} target - 스킬의 대상 (사거리 체크용)
      */
-    recordSkillUse(unit, skill) {
+    recordSkillUse(unit, skill, target = null) {
         if (!this.canUseSkill(unit, skill)) return;
+
+        if (target) {
+            const attackRange = skill.range ?? unit.finalStats.attackRange ?? 1;
+            const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
+            if (distance > attackRange) {
+                debugLogEngine.log(
+                    'SkillEngine',
+                    `${unit.instanceName} attempted [${skill.name}] out of range (distance ${distance}, range ${attackRange}).`
+                );
+                return;
+            }
+        }
 
         // 토큰 소모
         tokenEngine.spendTokens(unit.uniqueId, skill.cost);

--- a/tests/commander_infinite_range_bug_test.js
+++ b/tests/commander_infinite_range_bug_test.js
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import './setup-indexeddb.js';
+import IsSkillInRangeNode from '../src/ai/nodes/IsSkillInRangeNode.js';
+import Blackboard from '../src/ai/Blackboard.js';
+import { skillEngine } from '../src/game/utils/SkillEngine.js';
+import { tokenEngine } from '../src/game/utils/TokenEngine.js';
+
+// Commander and enemy units placed 6 tiles apart
+const commander = {
+    uniqueId: 1,
+    id: 'commander',
+    instanceName: 'Commander',
+    team: 'ally',
+    gridX: 0,
+    gridY: 0,
+    finalStats: { attackRange: 2 }
+};
+
+const enemy = {
+    uniqueId: 2,
+    id: 'enemy',
+    instanceName: 'Enemy',
+    team: 'enemy',
+    gridX: 0,
+    gridY: 6,
+    finalStats: {}
+};
+
+// Initialize token system
+// Both units are stationary and cannot move; only tokens matter
+// Commander receives default 3 tokens at turn start
+// so skillEngine will allow use if range is not checked
+
+tokenEngine.initializeUnits([commander, enemy]);
+tokenEngine.addTokensForNewTurn();
+
+// Skill with range 2 (same as commander attack range)
+const skill = {
+    id: 'testSkill',
+    name: 'Test Skill',
+    type: 'ACTIVE',
+    cost: 1,
+    cooldown: 0,
+    range: 2
+};
+
+// Verify target is out of range via AI node
+const rangeNode = new IsSkillInRangeNode();
+const bb = new Blackboard();
+bb.set('skillTarget', enemy);
+bb.set('currentSkillData', skill);
+const rangeResult = await rangeNode.evaluate(commander, bb);
+assert.strictEqual(rangeResult, 'FAILURE', 'Target should be out of range');
+
+// Attempt to use skill regardless of range
+const tokensBefore = tokenEngine.getTokens(commander.uniqueId);
+skillEngine.recordSkillUse(commander, skill, enemy);
+const tokensAfter = tokenEngine.getTokens(commander.uniqueId);
+
+// Expected correct behavior: tokens should not change because skill is out of range
+// Current bug: tokens decrease, meaning skillEngine allows infinite-range usage
+assert.strictEqual(tokensAfter, tokensBefore, 'Tokens should not be spent when target is out of range');
+
+console.log('✅ Commander range check enforced');

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -602,7 +602,7 @@ for (let turn = 1; turn <= 5; turn++) {
     for (const skill of rankedSkills) {
         if (skill.type === 'PASSIVE') continue;
         if (skillEngine.canUseSkill(soldier, skill)) {
-            skillEngine.recordSkillUse(soldier, skill);
+            skillEngine.recordSkillUse(soldier, skill, skill.target);
             if (skill.effect) {
                 const effectCopy = JSON.parse(JSON.stringify(skill.effect));
                 effectCopy.remaining = effectCopy.duration;


### PR DESCRIPTION
## Summary
- add regression test showing commander skills must respect range
- prevent token spending when skills target out-of-range units
- pass target references through AI nodes and simulator

## Testing
- `node tests/commander_infinite_range_bug_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/class_passive_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab08d32d108327a42d7e2a6882ed41