### PR TITLE
Add basic Vanguard fate synergy system

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1607,6 +1607,27 @@ body {
     cursor: help;
 }
 
+/* ✨ [신규] 시너지 태그 컨테이너 및 태그 스타일 */
+.synergy-tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+    padding: 6px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+    width: 100%;
+}
+
+.synergy-tag {
+    background-color: rgba(16, 185, 129, 0.2);
+    border: 1px solid rgba(16, 185, 129, 0.6);
+    color: #10b981;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 12px;
+}
+
 .unit-grades {
     display: flex;
     flex-direction: column;

--- a/src/game/data/synergies.js
+++ b/src/game/data/synergies.js
@@ -1,0 +1,12 @@
+export const fateSynergies = {
+    vanguard: {
+        name: '선봉대',
+        bonuses: [
+            { count: 4, multiplier: 1.05 },
+            { count: 6, multiplier: 1.10 },
+            { count: 8, multiplier: 1.20 },
+            { count: 10, multiplier: 1.30 },
+            { count: 12, multiplier: 1.50 }
+        ]
+    }
+};

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -10,6 +10,7 @@ import { classGrades } from '../data/classGrades.js';
 import { classProficiencies } from '../data/classProficiencies.js';
 // ✨ 새로 만든 특화 태그 데이터를 가져옵니다.
 import { classSpecializations } from '../data/classSpecializations.js';
+import { fateSynergies } from '../data/synergies.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -25,6 +26,7 @@ export class UnitDetailDOM {
         const specializations = classSpecializations[unitData.id] || [];
         // ✨ 1. 용병의 고유 속성 특화 정보를 가져옵니다.
         const attributeSpec = unitData.attributeSpec;
+        const synergies = unitData.synergies || {};
 
         // --- MBTI 문자열과 툴팁 텍스트를 준비합니다. ---
         const mbti = unitData.mbti;
@@ -159,12 +161,22 @@ export class UnitDetailDOM {
                 </div>
             </div>
         `;
+        const synergySectionHTML = `
+            <div class="synergy-section">
+                <div class="section-title">시너지</div>
+                <div class="synergy-tags-container">
+                    ${synergies.fate ? `<span class="synergy-tag">${fateSynergies[synergies.fate]?.name || synergies.fate}</span>` : ''}
+                    ${synergies.attribute ? `<span class="synergy-tag">${synergies.attribute}</span>` : ''}
+                </div>
+            </div>
+        `;
         // =======================================================================
         // ✨ [수정] 클래스 패시브 섹션이 위로 이동했으므로 여기서는 제거합니다.
         // =======================================================================
         leftSection.innerHTML = `
             ${gradeDisplayHTML}
             ${statsContainerHTML}
+            ${synergySectionHTML}
         `;
         // =======================================================================
 

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -11,6 +11,9 @@ import { diceEngine } from './DiceEngine.js';
 import { archetypeAssignmentEngine } from './ArchetypeAssignmentEngine.js';
 // MBTI 매핑을 불러옵니다.
 import { CLASS_MBTI_MAP, mbtiFromString } from '../data/classMbtiMap.js';
+// ✨ [신규] 운명 시너지와 시너지 엔진을 가져옵니다.
+import { fateSynergies } from '../data/synergies.js';
+import { synergyEngine } from './SynergyEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -74,6 +77,14 @@ class MercenaryEngine {
             newInstance.attributeSpec = randomAttribute;
         }
 
+        // ✨ [신규] 운명 시너지를 랜덤으로 부여합니다.
+        const fateKeys = Object.keys(fateSynergies);
+        const randomFate = diceEngine.getRandomElement(fateKeys);
+        newInstance.synergies = {
+            fate: randomFate,
+            attribute: randomAttribute ? randomAttribute.tag : null
+        };
+
         // ✨ 모든 클래스가 동일한 슬롯 구조를 사용하므로 추가 로직이 필요 없습니다.
 
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
@@ -83,9 +94,11 @@ class MercenaryEngine {
             birthReportManager.logNewUnit(newInstance, '아군');
             // --- 파티에 추가 ---
             partyEngine.addPartyMember(uniqueId);
+            synergyEngine.updateAllies(Array.from(this.alliedMercenaries.values()));
         } else {
             this.enemyMercenaries.set(uniqueId, newInstance);
             birthReportManager.logNewUnit(newInstance, '적군');
+            synergyEngine.updateEnemies(Array.from(this.enemyMercenaries.values()));
         }
         
         return newInstance;

--- a/src/game/utils/SynergyEngine.js
+++ b/src/game/utils/SynergyEngine.js
@@ -1,0 +1,44 @@
+import { statEngine } from './StatEngine.js';
+import { fateSynergies } from '../data/synergies.js';
+
+class SynergyEngine {
+    _applyFateSynergies(units) {
+        const counts = {};
+        units.forEach(u => {
+            const fate = u.synergies?.fate;
+            if (fate) {
+                counts[fate] = (counts[fate] || 0) + 1;
+            }
+        });
+        units.forEach(u => {
+            const fate = u.synergies?.fate;
+            if (!fate) return;
+            const def = fateSynergies[fate];
+            if (!def) return;
+            const count = counts[fate] || 0;
+            let multiplier = 1;
+            def.bonuses.forEach(b => {
+                if (count >= b.count) multiplier = b.multiplier;
+            });
+            u.finalStats.hp = Math.round(u.baseStats.hp * multiplier);
+        });
+    }
+
+    _recalcStats(units) {
+        units.forEach(u => {
+            u.finalStats = statEngine.calculateStats(u, u.baseStats, u.equippedItems || []);
+        });
+    }
+
+    updateAllies(units) {
+        this._recalcStats(units);
+        this._applyFateSynergies(units);
+    }
+
+    updateEnemies(units) {
+        this._recalcStats(units);
+        this._applyFateSynergies(units);
+    }
+}
+
+export const synergyEngine = new SynergyEngine();

--- a/tests/vanguard_synergy_test.js
+++ b/tests/vanguard_synergy_test.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+import { mercenaryEngine } from '../src/game/utils/MercenaryEngine.js';
+import { partyEngine } from '../src/game/utils/PartyEngine.js';
+
+// reset state
+mercenaryEngine.alliedMercenaries.clear();
+partyEngine.partyMembers = new Array(partyEngine.maxPartySize).fill(undefined);
+
+for (let i = 0; i < 4; i++) {
+    mercenaryEngine.hireMercenary(mercenaryData.warrior, 'ally');
+}
+
+const allies = mercenaryEngine.getAllAlliedMercenaries();
+allies.forEach(unit => {
+    assert.strictEqual(unit.synergies.fate, 'vanguard');
+    assert.strictEqual(unit.finalStats.hp, Math.round(unit.baseStats.hp * 1.05));
+});
+
+console.log('Vanguard synergy test passed.');


### PR DESCRIPTION
## Summary
- implement fate synergy data and engine applying Vanguard HP bonuses
- assign random fate and attribute synergies to mercenaries and show them in unit details
- style and display synergy tags and add Vanguard synergy test

## Testing
- `node tests/vanguard_synergy_test.js`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a3847948327a2150e3d9831ce50