### PR TITLE
feat: show active synergies

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1628,6 +1628,44 @@ body {
     border-radius: 12px;
 }
 
+#active-synergy-container {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(16, 185, 129, 0.6);
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: #10b981;
+    z-index: 50;
+}
+
+.active-synergy-item {
+    font-size: 12px;
+}
+
+.synergy-tooltip {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.85);
+    border: 1px solid rgba(16, 185, 129, 0.6);
+    color: #fff;
+    padding: 8px;
+    pointer-events: none;
+    z-index: 1000;
+    font-size: 12px;
+}
+
+.synergy-tooltip-name {
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+
+.synergy-tooltip-line.active {
+    color: #fbbf24;
+}
+
 .unit-grades {
     display: flex;
     flex-direction: column;

--- a/src/game/dom/ArenaDOMEngine.js
+++ b/src/game/dom/ArenaDOMEngine.js
@@ -4,6 +4,8 @@ import { formationEngine } from '../utils/FormationEngine.js';
 import { arenaManager } from '../utils/ArenaManager.js';
 // ✨ UnitDetailDOM을 import하여 게임 내 상세 정보창을 사용합니다.
 import { UnitDetailDOM } from './UnitDetailDOM.js';
+import { synergyEngine } from '../utils/SynergyEngine.js';
+import { SynergyTooltipManager } from './SynergyTooltipManager.js';
 
 export class ArenaDOMEngine {
     constructor(scene, domEngine) {
@@ -51,6 +53,11 @@ export class ArenaDOMEngine {
 
         this.placeUnits();
         this.placeEnemyUnits(); // 적 유닛 배치
+
+        this.synergyContainer = document.createElement('div');
+        this.synergyContainer.id = 'active-synergy-container';
+        this.container.appendChild(this.synergyContainer);
+        this.renderSynergySummary();
 
         const backButton = document.createElement('div');
         backButton.id = 'formation-back-button';
@@ -123,6 +130,7 @@ export class ArenaDOMEngine {
             const otherId = parseInt(targetUnit.dataset.unitId);
             if (otherId) formationEngine.setPosition(otherId, parseInt(fromCell.dataset.index));
         }
+        this.renderSynergySummary();
     }
 
     // ✨ [수정] 적 유닛 배치 로직 수정
@@ -185,5 +193,19 @@ export class ArenaDOMEngine {
     destroy() {
         this.container.innerHTML = '';
         this.hide();
+    }
+
+    renderSynergySummary() {
+        const units = partyEngine.getDeployedMercenaries();
+        const summary = synergyEngine.getFateSynergySummary(units);
+        this.synergyContainer.innerHTML = '';
+        summary.forEach(s => {
+            const div = document.createElement('div');
+            div.className = 'active-synergy-item';
+            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
+            div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
+            this.synergyContainer.appendChild(div);
+        });
     }
 }

--- a/src/game/dom/FormationDOMEngine.js
+++ b/src/game/dom/FormationDOMEngine.js
@@ -1,6 +1,8 @@
 import { partyEngine } from '../utils/PartyEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { formationEngine } from '../utils/FormationEngine.js';
+import { synergyEngine } from '../utils/SynergyEngine.js';
+import { SynergyTooltipManager } from './SynergyTooltipManager.js';
 
 export class FormationDOMEngine {
     constructor(scene, domEngine) {
@@ -47,6 +49,11 @@ export class FormationDOMEngine {
         }
 
         this.placeUnits();
+
+        this.synergyContainer = document.createElement('div');
+        this.synergyContainer.id = 'active-synergy-container';
+        this.container.appendChild(this.synergyContainer);
+        this.renderSynergySummary();
 
         const backButton = document.createElement('div');
         backButton.id = 'formation-back-button';
@@ -119,6 +126,7 @@ export class FormationDOMEngine {
             const otherId = parseInt(targetUnit.dataset.unitId);
             if (otherId) formationEngine.setPosition(otherId, parseInt(fromCell.dataset.index));
         }
+        this.renderSynergySummary();
     }
 
     hide() {
@@ -128,5 +136,19 @@ export class FormationDOMEngine {
     destroy() {
         this.container.innerHTML = '';
         this.hide();
+    }
+
+    renderSynergySummary() {
+        const units = partyEngine.getDeployedMercenaries();
+        const summary = synergyEngine.getFateSynergySummary(units);
+        this.synergyContainer.innerHTML = '';
+        summary.forEach(s => {
+            const div = document.createElement('div');
+            div.className = 'active-synergy-item';
+            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
+            div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
+            this.synergyContainer.appendChild(div);
+        });
     }
 }

--- a/src/game/dom/PartyDOMEngine.js
+++ b/src/game/dom/PartyDOMEngine.js
@@ -1,6 +1,9 @@
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
 // ✨ [변경] statEngine 대신 UnitDetailDOM을 import 합니다.
 import { UnitDetailDOM } from './UnitDetailDOM.js';
+import { synergyEngine } from '../utils/SynergyEngine.js';
+import { SynergyTooltipManager } from './SynergyTooltipManager.js';
 
 /**
  * 파티 관리 화면의 DOM 요소를 생성하고 관리하는 엔진
@@ -18,8 +21,13 @@ export class PartyDOMEngine {
         this.activeGrid = null;
         this.reserveGrid = null;
         this.unitDetailView = null;
+        this.synergyContainer = null;
 
         this.container.style.display = 'block';
+
+        this.synergyContainer = document.createElement('div');
+        this.synergyContainer.id = 'active-synergy-container';
+        this.container.appendChild(this.synergyContainer);
 
         this.createGrid();
         this.addBackButton();
@@ -123,6 +131,7 @@ export class PartyDOMEngine {
     refresh() {
         this.renderPartyMembers();
         this.renderReserveMembers();
+        this.renderSynergySummary();
     }
 
     addBackButton() {
@@ -164,5 +173,19 @@ export class PartyDOMEngine {
         if (this.unitDetailView) this.unitDetailView.remove();
         this.container.innerHTML = '';
         this.hide();
+    }
+
+    renderSynergySummary() {
+        const units = partyEngine.getDeployedMercenaries();
+        const summary = synergyEngine.getFateSynergySummary(units);
+        this.synergyContainer.innerHTML = '';
+        summary.forEach(s => {
+            const div = document.createElement('div');
+            div.className = 'active-synergy-item';
+            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
+            div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
+            this.synergyContainer.appendChild(div);
+        });
     }
 }

--- a/src/game/dom/SynergyTooltipManager.js
+++ b/src/game/dom/SynergyTooltipManager.js
@@ -1,0 +1,26 @@
+import { fateSynergies } from '../data/synergies.js';
+
+export class SynergyTooltipManager {
+    static show(key, count, event) {
+        this.hide();
+        const def = fateSynergies[key];
+        if (!def) return;
+        const tooltip = document.createElement('div');
+        tooltip.id = 'synergy-tooltip';
+        tooltip.className = 'synergy-tooltip';
+        let html = `<div class="synergy-tooltip-name">${def.name}</div>`;
+        def.bonuses.forEach(b => {
+            const active = count >= b.count ? 'active' : '';
+            html += `<div class="synergy-tooltip-line ${active}">${b.count}명: HP x${b.multiplier}</div>`;
+        });
+        tooltip.innerHTML = html;
+        document.body.appendChild(tooltip);
+        tooltip.style.left = `${event.pageX + 15}px`;
+        tooltip.style.top = `${event.pageY + 15}px`;
+    }
+
+    static hide() {
+        const existing = document.getElementById('synergy-tooltip');
+        if (existing) existing.remove();
+    }
+}

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -11,6 +11,9 @@ import { classProficiencies } from '../data/classProficiencies.js';
 // ✨ 새로 만든 특화 태그 데이터를 가져옵니다.
 import { classSpecializations } from '../data/classSpecializations.js';
 import { fateSynergies } from '../data/synergies.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { synergyEngine } from '../utils/SynergyEngine.js';
+import { SynergyTooltipManager } from './SynergyTooltipManager.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -27,6 +30,9 @@ export class UnitDetailDOM {
         // ✨ 1. 용병의 고유 속성 특화 정보를 가져옵니다.
         const attributeSpec = unitData.attributeSpec;
         const synergies = unitData.synergies || {};
+        const deployed = partyEngine.getDeployedMercenaries();
+        const fateSummary = synergyEngine.getFateSynergySummary(deployed);
+        const activeFateCount = synergies.fate ? (fateSummary.find(s => s.key === synergies.fate)?.count || 0) : 0;
 
         // --- MBTI 문자열과 툴팁 텍스트를 준비합니다. ---
         const mbti = unitData.mbti;
@@ -178,6 +184,11 @@ export class UnitDetailDOM {
             ${statsContainerHTML}
             ${synergySectionHTML}
         `;
+        const fateTag = leftSection.querySelector('.synergy-tag');
+        if (fateTag && synergies.fate) {
+            fateTag.addEventListener('mouseenter', (e) => SynergyTooltipManager.show(synergies.fate, activeFateCount, e));
+            fateTag.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
+        }
         // =======================================================================
 
         const rightSection = document.createElement('div');

--- a/src/game/utils/SynergyEngine.js
+++ b/src/game/utils/SynergyEngine.js
@@ -39,6 +39,30 @@ class SynergyEngine {
         this._recalcStats(units);
         this._applyFateSynergies(units);
     }
+
+    getFateSynergySummary(units) {
+        const counts = {};
+        units.forEach(u => {
+            const fate = u.synergies?.fate;
+            if (fate) counts[fate] = (counts[fate] || 0) + 1;
+        });
+        return Object.entries(counts).map(([key, count]) => {
+            const def = fateSynergies[key];
+            let multiplier = 1;
+            if (def) {
+                def.bonuses.forEach(b => {
+                    if (count >= b.count) multiplier = b.multiplier;
+                });
+            }
+            return {
+                key,
+                name: def?.name || key,
+                count,
+                multiplier,
+                bonuses: def?.bonuses || []
+            };
+        });
+    }
 }
 
 export const synergyEngine = new SynergyEngine();


### PR DESCRIPTION
## Summary
- show active fate synergies in party, formation, and arena screens
- add hover tooltip detailing synergy bonuses and highlight current tier
- expose party synergy counts from SynergyEngine and style new UI elements

## Testing
- `node tests/vanguard_synergy_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab1df75dd08327af77db375a7625a8