### PR TITLE
Add hit chance and dodge feedback to combat engine

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -43,12 +43,21 @@ class AttackTargetNode extends Node {
         // 공격 애니메이션
         await this.animationEngine.attack(unit.sprite, target.sprite);
 
-        // 피격 스프라이트로 변경
-        spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
-
         // 데미지 계산 및 적용
         // ✨ 데미지 계산 시 스킬 정보 전달
         const { damage, hitType, comboCount } = this.combatEngine.calculateDamage(unit, target, attackSkill);
+
+        if (hitType === '회피') {
+            this.vfxManager.showComboCount(comboCount);
+            this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, 0, '#a3a3a3', '회피');
+            await this.delayEngine.hold(200);
+            debugAIManager.logNodeResult(NodeState.SUCCESS);
+            return NodeState.SUCCESS;
+        }
+
+        // 피격 스프라이트로 변경
+        spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
+
         target.currentHp -= damage;
 
         // 시각 효과

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -122,6 +122,22 @@ class CombatCalculationEngine {
         const isMagic = skill.tags?.includes(SKILL_TAGS.MAGIC);
         const isRanged = skill.tags?.includes(SKILL_TAGS.RANGED) && skill.tags?.includes(SKILL_TAGS.PHYSICAL);
 
+        // --- [신규] 명중 판정 로직 ---
+        const accuracyBuff = statusEffectManager.getModifierValue(attacker, 'accuracy');
+        const evadeStatKey = isMagic ? 'magicEvadeChance' : 'physicalEvadeChance';
+        const evadeBuff = statusEffectManager.getModifierValue(defender, evadeStatKey);
+
+        let attackerAccuracy = attackerStats.accuracy ?? 1;
+        if (attackerAccuracy > 1) attackerAccuracy /= 100;
+        let defenderEvade = defenderStats?.[evadeStatKey] ?? 0;
+        if (defenderEvade > 1) defenderEvade /= 100;
+
+        const hitChance = attackerAccuracy + accuracyBuff - (defenderEvade + evadeBuff);
+        if (Math.random() > hitChance) {
+            debugCombatLogManager.logAttackCalculation(attacker, defender, 0, 0, 0);
+            return { damage: 0, hitType: '회피', comboCount: 0 };
+        }
+
         // 1. 공격자의 공격력 버프/디버프 보정치를 가져옵니다.
         const attackStatKey = isMagic ? 'magicAttack' : 'physicalAttack';
         const attackBuffPercent = statusEffectManager.getModifierValue(attacker, attackStatKey);

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -480,6 +480,11 @@ class SkillEffectProcessor {
 
     // --- [신규] 피해 적용 로직을 별도 메서드로 추출 ---
     _applyDamage(target, damage, hitType, color = '#ff4d4d') {
+        if (hitType === '회피') {
+            this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, 0, '#a3a3a3', '회피');
+            return 0;
+        }
+
         const damageToBarrier = Math.min(target.currentBarrier, damage);
         const damageToHp = damage - damageToBarrier;
 


### PR DESCRIPTION
## Summary
- add accuracy vs evade roll to CombatCalculationEngine to support misses
- show '회피' in damage numbers and skip blood on dodged attacks
- handle dodge label in SkillEffectProcessor for all damage applications

## Testing
- `node tests/combat_calculation_test.js`
- `node tests/class_passive_integration_test.js`
- `node tests/critical_shot_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab25652644832788069cbc41164a56