### PR TITLE
Add new fate synergies and tests

### DIFF
--- a/src/game/data/synergies.js
+++ b/src/game/data/synergies.js
@@ -1,12 +1,50 @@
 export const fateSynergies = {
     vanguard: {
         name: '선봉대',
+        stat: 'hp',
+        statName: 'HP',
         bonuses: [
             { count: 4, multiplier: 1.05 },
             { count: 6, multiplier: 1.10 },
             { count: 8, multiplier: 1.20 },
             { count: 10, multiplier: 1.30 },
             { count: 12, multiplier: 1.50 }
+        ]
+    },
+    striker: {
+        name: '타격대',
+        stat: 'physicalAttack',
+        statName: '물리 공격력',
+        bonuses: [
+            { count: 4, multiplier: 1.10 },
+            { count: 6, multiplier: 1.20 },
+            { count: 8, multiplier: 1.40 },
+            { count: 10, multiplier: 1.60 },
+            { count: 12, multiplier: 1.80 }
+        ]
+    },
+    oathkeeper: {
+        name: '서약자',
+        stat: 'maxBarrier',
+        statName: '용맹 배리어',
+        bonuses: [
+            { count: 4, multiplier: 1.10 },
+            { count: 6, multiplier: 1.20 },
+            { count: 8, multiplier: 1.35 },
+            { count: 10, multiplier: 1.50 },
+            { count: 12, multiplier: 1.60 }
+        ]
+    },
+    acrobat: {
+        name: '곡예사',
+        stat: ['physicalEvadeChance', 'magicEvadeChance'],
+        statName: '회피율',
+        bonuses: [
+            { count: 4, multiplier: 1.05 },
+            { count: 6, multiplier: 1.10 },
+            { count: 8, multiplier: 1.15 },
+            { count: 10, multiplier: 1.20 },
+            { count: 12, multiplier: 1.30 }
         ]
     }
 };

--- a/src/game/dom/ArenaDOMEngine.js
+++ b/src/game/dom/ArenaDOMEngine.js
@@ -202,7 +202,7 @@ export class ArenaDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/FormationDOMEngine.js
+++ b/src/game/dom/FormationDOMEngine.js
@@ -145,7 +145,7 @@ export class FormationDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/PartyDOMEngine.js
+++ b/src/game/dom/PartyDOMEngine.js
@@ -182,7 +182,7 @@ export class PartyDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: HP x${s.multiplier} (${s.count})`;
+            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/SynergyTooltipManager.js
+++ b/src/game/dom/SynergyTooltipManager.js
@@ -11,7 +11,7 @@ export class SynergyTooltipManager {
         let html = `<div class="synergy-tooltip-name">${def.name}</div>`;
         def.bonuses.forEach(b => {
             const active = count >= b.count ? 'active' : '';
-            html += `<div class="synergy-tooltip-line ${active}">${b.count}명: HP x${b.multiplier}</div>`;
+            html += `<div class="synergy-tooltip-line ${active}">${b.count}명: ${def.statName || 'HP'} x${b.multiplier}</div>`;
         });
         tooltip.innerHTML = html;
         document.body.appendChild(tooltip);

--- a/src/game/utils/SynergyEngine.js
+++ b/src/game/utils/SynergyEngine.js
@@ -20,7 +20,14 @@ class SynergyEngine {
             def.bonuses.forEach(b => {
                 if (count >= b.count) multiplier = b.multiplier;
             });
-            u.finalStats.hp = Math.round(u.baseStats.hp * multiplier);
+            const stats = Array.isArray(def.stat) ? def.stat : [def.stat || 'hp'];
+            stats.forEach(statKey => {
+                const baseValue = u.finalStats[statKey] || 0;
+                u.finalStats[statKey] = Math.round(baseValue * multiplier);
+            });
+            if (stats.includes('maxBarrier')) {
+                u.finalStats.currentBarrier = u.finalStats.maxBarrier;
+            }
         });
     }
 
@@ -59,6 +66,7 @@ class SynergyEngine {
                 name: def?.name || key,
                 count,
                 multiplier,
+                statName: def?.statName || 'HP',
                 bonuses: def?.bonuses || []
             };
         });

--- a/tests/additional_synergies_test.js
+++ b/tests/additional_synergies_test.js
@@ -1,0 +1,51 @@
+import assert from 'assert';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+import { mercenaryEngine } from '../src/game/utils/MercenaryEngine.js';
+import { partyEngine } from '../src/game/utils/PartyEngine.js';
+import { synergyEngine } from '../src/game/utils/SynergyEngine.js';
+import { statEngine } from '../src/game/utils/StatEngine.js';
+
+function reset() {
+    mercenaryEngine.alliedMercenaries.clear();
+    partyEngine.partyMembers = new Array(partyEngine.maxPartySize).fill(undefined);
+}
+
+function hireWithSynergy(count, key, setupFn = () => {}) {
+    const units = [];
+    for (let i = 0; i < count; i++) {
+        const unit = mercenaryEngine.hireMercenary(mercenaryData.warrior, 'ally');
+        setupFn(unit);
+        unit.synergies.fate = key;
+        units.push(unit);
+    }
+    synergyEngine.updateAllies(units);
+    return units;
+}
+
+// 타격대: 물리 공격력 증가
+reset();
+let units = hireWithSynergy(12, 'striker');
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).physicalAttack;
+    assert.strictEqual(unit.finalStats.physicalAttack, Math.round(base * 1.8));
+});
+console.log('Striker synergy test passed.');
+
+// 서약자: 용맹 배리어 수치 증가
+reset();
+units = hireWithSynergy(12, 'oathkeeper');
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).maxBarrier;
+    assert.strictEqual(unit.finalStats.maxBarrier, Math.round(base * 1.6));
+});
+console.log('Oathkeeper synergy test passed.');
+
+// 곡예사: 회피율 증가
+reset();
+units = hireWithSynergy(12, 'acrobat', u => { u.baseStats.physicalEvadeChance = 10; });
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).physicalEvadeChance;
+    assert.strictEqual(unit.finalStats.physicalEvadeChance, Math.round(base * 1.3));
+});
+console.log('Acrobat synergy test passed.');
+

--- a/tests/vanguard_synergy_test.js
+++ b/tests/vanguard_synergy_test.js
@@ -2,17 +2,22 @@ import assert from 'assert';
 import { mercenaryData } from '../src/game/data/mercenaries.js';
 import { mercenaryEngine } from '../src/game/utils/MercenaryEngine.js';
 import { partyEngine } from '../src/game/utils/PartyEngine.js';
+import { synergyEngine } from '../src/game/utils/SynergyEngine.js';
 
 // reset state
 mercenaryEngine.alliedMercenaries.clear();
 partyEngine.partyMembers = new Array(partyEngine.maxPartySize).fill(undefined);
 
+const created = [];
 for (let i = 0; i < 4; i++) {
-    mercenaryEngine.hireMercenary(mercenaryData.warrior, 'ally');
+    const unit = mercenaryEngine.hireMercenary(mercenaryData.warrior, 'ally');
+    unit.synergies.fate = 'vanguard';
+    created.push(unit);
 }
+// 재계산
+synergyEngine.updateAllies(created);
 
-const allies = mercenaryEngine.getAllAlliedMercenaries();
-allies.forEach(unit => {
+created.forEach(unit => {
     assert.strictEqual(unit.synergies.fate, 'vanguard');
     assert.strictEqual(unit.finalStats.hp, Math.round(unit.baseStats.hp * 1.05));
 });


### PR DESCRIPTION
## Summary
- Add new Striker, Oathkeeper, and Acrobat fate synergies that boost attack, valor barrier, and evasion
- Generalize synergy engine and tooltips to handle different stat types
- Cover synergies with dedicated tests

## Testing
- `node tests/vanguard_synergy_test.js`
- `node tests/additional_synergies_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab27d88a3c8327852ab15a7fc53d67