### PR TITLE
feat: add new fate synergies

### DIFF
--- a/src/game/data/synergies.js
+++ b/src/game/data/synergies.js
@@ -46,5 +46,54 @@ export const fateSynergies = {
             { count: 10, multiplier: 1.20 },
             { count: 12, multiplier: 1.30 }
         ]
+    },
+    seeker: {
+        name: '탐구자',
+        stat: 'magicAttack',
+        statName: '마법 공격력',
+        bonuses: [
+            { count: 4, multiplier: 1.10 },
+            { count: 6, multiplier: 1.20 },
+            { count: 8, multiplier: 1.40 },
+            { count: 10, multiplier: 1.60 },
+            { count: 12, multiplier: 1.80 }
+        ]
+    },
+    supporter: {
+        name: '조력자',
+        stat: 'aspirationRegen',
+        statName: '열망 회복',
+        mode: 'add',
+        bonuses: [
+            { count: 4, multiplier: 5 },
+            { count: 6, multiplier: 7 },
+            { count: 8, multiplier: 9 },
+            { count: 10, multiplier: 12 },
+            { count: 12, multiplier: 15 }
+        ]
+    },
+    guardian: {
+        name: '수호자',
+        stat: 'physicalDefense',
+        statName: '물리 방어력',
+        bonuses: [
+            { count: 4, multiplier: 1.10 },
+            { count: 6, multiplier: 1.20 },
+            { count: 8, multiplier: 1.30 },
+            { count: 10, multiplier: 1.45 },
+            { count: 12, multiplier: 1.60 }
+        ]
+    },
+    purifier: {
+        name: '정화자',
+        stat: 'magicDefense',
+        statName: '마법 방어력',
+        bonuses: [
+            { count: 4, multiplier: 1.10 },
+            { count: 6, multiplier: 1.20 },
+            { count: 8, multiplier: 1.30 },
+            { count: 10, multiplier: 1.45 },
+            { count: 12, multiplier: 1.60 }
+        ]
     }
 };

--- a/src/game/dom/ArenaDOMEngine.js
+++ b/src/game/dom/ArenaDOMEngine.js
@@ -202,7 +202,8 @@ export class ArenaDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
+            const symbol = s.mode === 'add' ? '+' : 'x';
+            div.innerText = `${s.name}: ${s.statName} ${symbol}${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/FormationDOMEngine.js
+++ b/src/game/dom/FormationDOMEngine.js
@@ -145,7 +145,8 @@ export class FormationDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
+            const symbol = s.mode === 'add' ? '+' : 'x';
+            div.innerText = `${s.name}: ${s.statName} ${symbol}${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/PartyDOMEngine.js
+++ b/src/game/dom/PartyDOMEngine.js
@@ -182,7 +182,8 @@ export class PartyDOMEngine {
         summary.forEach(s => {
             const div = document.createElement('div');
             div.className = 'active-synergy-item';
-            div.innerText = `${s.name}: ${s.statName} x${s.multiplier} (${s.count})`;
+            const symbol = s.mode === 'add' ? '+' : 'x';
+            div.innerText = `${s.name}: ${s.statName} ${symbol}${s.multiplier} (${s.count})`;
             div.addEventListener('mouseenter', e => SynergyTooltipManager.show(s.key, s.count, e));
             div.addEventListener('mouseleave', () => SynergyTooltipManager.hide());
             this.synergyContainer.appendChild(div);

--- a/src/game/dom/SynergyTooltipManager.js
+++ b/src/game/dom/SynergyTooltipManager.js
@@ -11,7 +11,8 @@ export class SynergyTooltipManager {
         let html = `<div class="synergy-tooltip-name">${def.name}</div>`;
         def.bonuses.forEach(b => {
             const active = count >= b.count ? 'active' : '';
-            html += `<div class="synergy-tooltip-line ${active}">${b.count}명: ${def.statName || 'HP'} x${b.multiplier}</div>`;
+            const symbol = def.mode === 'add' ? '+' : 'x';
+            html += `<div class="synergy-tooltip-line ${active}">${b.count}명: ${def.statName || 'HP'} ${symbol}${b.multiplier}</div>`;
         });
         tooltip.innerHTML = html;
         document.body.appendChild(tooltip);

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -280,6 +280,10 @@ export class BattleSimulatorEngine {
             // ✨ [신규] 턴 시작 시 동적 패시브 효과를 적용합니다.
             if (currentUnit && currentUnit.currentHp > 0) {
                 statEngine.handleTurnStartPassives(currentUnit, this.turnQueue);
+                const regen = currentUnit.finalStats.aspirationRegen || 0;
+                if (regen > 0) {
+                    aspirationEngine.addAspiration(currentUnit.uniqueId, regen, '턴 회복');
+                }
             }
 
             // 현재 턴 표시를 위해 턴 순서 UI 업데이트

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -199,7 +199,8 @@ class StatEngine {
             'movement', 'attackRange', 'weight', 'physicalAttack', 'magicAttack', 'rangedAttack',
             'physicalDefense', 'magicDefense', 'rangedDefense', 'criticalChance', 'criticalDamageMultiplier',
             'physicalEvadeChance', 'magicEvadeChance', 'statusEffectResistance', 'statusEffectApplication',
-            'maxBarrier', 'currentBarrier', 'totalWeight', 'turnValue', 'physicalAttackPercentage', 'magicAttackPercentage'
+            'maxBarrier', 'currentBarrier', 'totalWeight', 'turnValue', 'physicalAttackPercentage', 'magicAttackPercentage',
+            'aspirationRegen'
         ];
 
         allStatKeys.forEach(key => {

--- a/src/game/utils/SynergyEngine.js
+++ b/src/game/utils/SynergyEngine.js
@@ -16,14 +16,18 @@ class SynergyEngine {
             const def = fateSynergies[fate];
             if (!def) return;
             const count = counts[fate] || 0;
-            let multiplier = 1;
+            let effect = def.mode === 'add' ? 0 : 1;
             def.bonuses.forEach(b => {
-                if (count >= b.count) multiplier = b.multiplier;
+                if (count >= b.count) effect = b.multiplier;
             });
             const stats = Array.isArray(def.stat) ? def.stat : [def.stat || 'hp'];
             stats.forEach(statKey => {
                 const baseValue = u.finalStats[statKey] || 0;
-                u.finalStats[statKey] = Math.round(baseValue * multiplier);
+                if (def.mode === 'add') {
+                    u.finalStats[statKey] = baseValue + effect;
+                } else {
+                    u.finalStats[statKey] = Math.round(baseValue * effect);
+                }
             });
             if (stats.includes('maxBarrier')) {
                 u.finalStats.currentBarrier = u.finalStats.maxBarrier;
@@ -55,19 +59,20 @@ class SynergyEngine {
         });
         return Object.entries(counts).map(([key, count]) => {
             const def = fateSynergies[key];
-            let multiplier = 1;
+            let effect = def?.mode === 'add' ? 0 : 1;
             if (def) {
                 def.bonuses.forEach(b => {
-                    if (count >= b.count) multiplier = b.multiplier;
+                    if (count >= b.count) effect = b.multiplier;
                 });
             }
             return {
                 key,
                 name: def?.name || key,
                 count,
-                multiplier,
+                multiplier: effect,
                 statName: def?.statName || 'HP',
-                bonuses: def?.bonuses || []
+                bonuses: def?.bonuses || [],
+                mode: def?.mode || 'multiply'
             };
         });
     }

--- a/tests/additional_synergies_test.js
+++ b/tests/additional_synergies_test.js
@@ -49,3 +49,38 @@ units.forEach(unit => {
 });
 console.log('Acrobat synergy test passed.');
 
+// 탐구자: 마법 공격력 증가
+reset();
+units = hireWithSynergy(12, 'seeker');
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).magicAttack;
+    assert.strictEqual(unit.finalStats.magicAttack, Math.round(base * 1.8));
+});
+console.log('Seeker synergy test passed.');
+
+// 조력자: 열망 회복 증가
+reset();
+units = hireWithSynergy(12, 'supporter');
+units.forEach(unit => {
+    assert.strictEqual(unit.finalStats.aspirationRegen, 15);
+});
+console.log('Supporter synergy test passed.');
+
+// 수호자: 물리 방어력 증가
+reset();
+units = hireWithSynergy(12, 'guardian');
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).physicalDefense;
+    assert.strictEqual(unit.finalStats.physicalDefense, Math.round(base * 1.6));
+});
+console.log('Guardian synergy test passed.');
+
+// 정화자: 마법 방어력 증가
+reset();
+units = hireWithSynergy(12, 'purifier');
+units.forEach(unit => {
+    const base = statEngine.calculateStats(unit, unit.baseStats, unit.equippedItems).magicDefense;
+    assert.strictEqual(unit.finalStats.magicDefense, Math.round(base * 1.6));
+});
+console.log('Purifier synergy test passed.');
+


### PR DESCRIPTION
## Summary
- add Seeker, Supporter, Guardian, and Purifier fate synergies
- allow synergy engine to apply additive bonuses
- regenerate aspiration each turn based on Supporter synergy

## Testing
- `node tests/vanguard_synergy_test.js`
- `node tests/additional_synergies_test.js`
- `python3 -m http.server 8000 &` / `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab2f75d58c8327b993908d49ea4d7e