### PR TITLE
Guard skill usage and abort when out of range or lacking resources

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -28,7 +28,10 @@ class AttackTargetNode extends Node {
             debugAIManager.logNodeResult(NodeState.FAILURE, '일반 공격을 위한 토큰 부족');
             return NodeState.FAILURE;
         }
-        skillEngine.recordSkillUse(unit, attackSkill, target);
+        if (!skillEngine.recordSkillUse(unit, attackSkill, target)) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '일반 공격 실행 실패');
+            return NodeState.FAILURE;
+        }
 
         // 스킬 이름을 보여줍니다.
         const skillColor = SKILL_TYPES[attackSkill.type].color;

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -86,7 +86,10 @@ class UseSkillNode extends Node {
 
 
         // 스킬 사용 기록
-        this.skillEngine.recordSkillUse(unit, finalSkill, skillTarget);
+        if (!this.skillEngine.recordSkillUse(unit, finalSkill, skillTarget)) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${finalSkill.name}] 사용 실패`);
+            return NodeState.FAILURE;
+        }
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
         usedSkills.add(instanceId);
         blackboard.set('usedSkillsThisTurn', usedSkills);

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -90,10 +90,14 @@ class SkillEngine {
      * @param {object} unit - 스킬을 사용한 유닛
      * @param {object} skill - 사용한 스킬 데이터
      * @param {object|null} target - 스킬의 대상 (사거리 체크용)
-     */
+    */
     recordSkillUse(unit, skill, target = null) {
-        if (!this.canUseSkill(unit, skill)) return;
+        // 기본 사용 가능 여부 확인
+        if (!this.canUseSkill(unit, skill)) {
+            return false;
+        }
 
+        // 사거리 체크 (대상 존재 시)
         if (target) {
             const attackRange = skill.range ?? unit.finalStats.attackRange ?? 1;
             const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
@@ -102,7 +106,7 @@ class SkillEngine {
                     'SkillEngine',
                     `${unit.instanceName} attempted [${skill.name}] out of range (distance ${distance}, range ${attackRange}).`
                 );
-                return;
+                return false;
             }
         }
 
@@ -138,6 +142,8 @@ class SkillEngine {
             'SkillEngine',
             `${unit.instanceName}이(가) 스킬 [${skillLabel}] 사용 (토큰 ${skill.cost} 소모).`
         );
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Return a boolean from `SkillEngine.recordSkillUse` to indicate success or failure
- Abort attack and skill nodes when a skill can't execute, logging the failure

## Testing
- `python3 -m http.server 8000 &` (served debug page)
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b63fb1483278f9e42bff5b73e87