### PR TITLE
feat: scale chain and revenge attacks by top stat

### DIFF
--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -119,7 +119,7 @@ class CombatCalculationEngine {
         const defenderStats = applyBraveryPassive(defender, applyReinforcementLearning(defender));
 
         // ✨ [핵심 수정] 마법, 원거리, 근접 순으로 공격 타입을 명확히 구분합니다.
-        const isMagic = skill.tags?.includes(SKILL_TAGS.MAGIC);
+        const isMagic = skill.attackStatKey === 'magicAttack' || skill.tags?.includes(SKILL_TAGS.MAGIC);
         const isRanged = skill.tags?.includes(SKILL_TAGS.RANGED) && skill.tags?.includes(SKILL_TAGS.PHYSICAL);
 
         // --- [신규] 명중 판정 로직 ---
@@ -139,12 +139,10 @@ class CombatCalculationEngine {
         }
 
         // 1. 공격자의 공격력 버프/디버프 보정치를 가져옵니다.
-        const attackStatKey = isMagic ? 'magicAttack' : 'physicalAttack';
+        const attackStatKey = skill.attackStatKey || (isMagic ? 'magicAttack' : 'physicalAttack');
         const attackBuffPercent = statusEffectManager.getModifierValue(attacker, attackStatKey);
 
-        const baseAttack = isMagic
-            ? (attackerStats?.magicAttack || 0)
-            : (attackerStats?.physicalAttack || 0); // isRanged는 physicalAttack을 공유
+        const baseAttack = attackerStats?.[attackStatKey] || 0;
 
         // 2. 기본 공격력에 버프를 적용합니다.
         const buffedAttack = baseAttack * (1 + attackBuffPercent);

--- a/src/game/utils/MBTIChainAttackEngine.js
+++ b/src/game/utils/MBTIChainAttackEngine.js
@@ -4,6 +4,7 @@ import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
 import { spriteEngine } from './SpriteEngine.js';
 import { debugChainRevengeManager } from '../debug/DebugChainRevengeManager.js';
+import { SKILL_TAGS } from './SkillTagManager.js';
 
 class MBTIChainAttackEngine {
   constructor() {
@@ -34,7 +35,32 @@ class MBTIChainAttackEngine {
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '체인 어택');
-        const chainSkill = { id: 'mbtiChain', name: '체인 어택', type: 'ACTIVE', damageMultiplier: 0.5 };
+
+        const stats = ally.finalStats || {};
+        const pa = stats.physicalAttack || 0;
+        const ra = stats.rangedAttack || 0;
+        const ma = stats.magicAttack || 0;
+
+        let attackStatKey = 'physicalAttack';
+        const tags = [SKILL_TAGS.ACTIVE];
+        if (ma >= pa && ma >= ra) {
+          attackStatKey = 'magicAttack';
+          tags.push(SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC);
+        } else if (ra >= pa && ra >= ma) {
+          attackStatKey = 'rangedAttack';
+          tags.push(SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL);
+        } else {
+          tags.push(SKILL_TAGS.MELEE, SKILL_TAGS.PHYSICAL);
+        }
+
+        const chainSkill = {
+          id: 'mbtiChain',
+          name: '체인 어택',
+          type: 'ACTIVE',
+          damageMultiplier: 0.5,
+          attackStatKey,
+          tags
+        };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, defender, chainSkill);
 
         if (ally.sprite && defender.sprite) {

--- a/src/game/utils/MBTIRevengeEngine.js
+++ b/src/game/utils/MBTIRevengeEngine.js
@@ -4,6 +4,7 @@ import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { mbtiToString } from '../data/classMbtiMap.js';
 import { spriteEngine } from './SpriteEngine.js';
 import { debugChainRevengeManager } from '../debug/DebugChainRevengeManager.js';
+import { SKILL_TAGS } from './SkillTagManager.js';
 
 class MBTIRevengeEngine {
   constructor() {
@@ -34,7 +35,32 @@ class MBTIRevengeEngine {
       const aspiration = aspirationData?.aspiration ?? 0;
       if (distance <= range && aspiration >= 10) {
         aspirationEngine.addAspiration(ally.uniqueId, -10, '리벤지 어택');
-        const revengeSkill = { id: 'mbtiRevenge', name: '리벤지 어택', type: 'ACTIVE', damageMultiplier: 0.5 };
+
+        const stats = ally.finalStats || {};
+        const pa = stats.physicalAttack || 0;
+        const ra = stats.rangedAttack || 0;
+        const ma = stats.magicAttack || 0;
+
+        let attackStatKey = 'physicalAttack';
+        const tags = [SKILL_TAGS.ACTIVE];
+        if (ma >= pa && ma >= ra) {
+          attackStatKey = 'magicAttack';
+          tags.push(SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC);
+        } else if (ra >= pa && ra >= ma) {
+          attackStatKey = 'rangedAttack';
+          tags.push(SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL);
+        } else {
+          tags.push(SKILL_TAGS.MELEE, SKILL_TAGS.PHYSICAL);
+        }
+
+        const revengeSkill = {
+          id: 'mbtiRevenge',
+          name: '리벤지 어택',
+          type: 'ACTIVE',
+          damageMultiplier: 0.5,
+          attackStatKey,
+          tags
+        };
         const { damage, hitType } = combatCalculationEngine.calculateDamage(ally, attacker, revengeSkill);
 
         if (ally.sprite && attacker.sprite) {

--- a/tests/mbti_chain_attack_engine_test.js
+++ b/tests/mbti_chain_attack_engine_test.js
@@ -23,7 +23,16 @@ const ally = {
   uniqueId: 2,
   team: 'ally',
   mbti: mbtiFromString('INTJ'),
-  finalStats: { hp: 100, physicalAttack: 30, physicalDefense: 0, attackRange: 1 },
+  finalStats: {
+    hp: 100,
+    physicalAttack: 10,
+    rangedAttack: 20,
+    magicAttack: 30,
+    physicalDefense: 0,
+    magicDefense: 0,
+    attackRange: 1,
+    accuracy: 1,
+  },
   currentHp: 100,
   currentBarrier: 0,
   gridX: 1,
@@ -35,7 +44,7 @@ const defender = {
   uniqueId: 3,
   team: 'enemy',
   mbti: mbtiFromString('ENTP'),
-  finalStats: { hp: 100, physicalDefense: 0 },
+  finalStats: { hp: 100, physicalDefense: 0, magicDefense: 0 },
   currentHp: 100,
   currentBarrier: 0,
   gridX: 1,
@@ -65,11 +74,14 @@ aspirationEngine.setBattleSimulator(battleSimulator);
 aspirationEngine.initializeUnits([attacker, ally, defender]);
 
 const beforeAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
+const originalRandom = Math.random;
+Math.random = () => 0.99; // avoid crit/weakness
 mbtiChainAttackEngine.handleAttack(attacker, defender, { type: 'ACTIVE' });
+Math.random = originalRandom;
 const afterAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
 
 assert.strictEqual(afterAsp, beforeAsp - 10, 'Aspiration should decrease by 10');
-assert(defender.currentHp < 100, 'Defender should take damage');
+assert.strictEqual(defender.currentHp, 85, 'Defender should take damage based on highest stat');
 assert(animationCalled, 'Animation should trigger');
 
 console.log('MBTI Chain Attack Engine test passed');

--- a/tests/mbti_revenge_engine_test.js
+++ b/tests/mbti_revenge_engine_test.js
@@ -24,7 +24,16 @@ const ally = {
   uniqueId: 2,
   team: 'ally',
   mbti: mbtiFromString('INTJ'),
-  finalStats: { hp: 100, physicalAttack: 30, physicalDefense: 0, attackRange: 1 },
+  finalStats: {
+    hp: 100,
+    physicalAttack: 10,
+    rangedAttack: 40,
+    magicAttack: 20,
+    physicalDefense: 0,
+    magicDefense: 0,
+    attackRange: 1,
+    accuracy: 1,
+  },
   currentHp: 100,
   currentBarrier: 0,
   gridX: 1,
@@ -36,7 +45,7 @@ const attacker = {
   uniqueId: 3,
   team: 'enemy',
   mbti: mbtiFromString('ENTP'),
-  finalStats: { hp: 100, physicalDefense: 0 },
+  finalStats: { hp: 100, physicalDefense: 0, magicDefense: 0 },
   currentHp: 100,
   currentBarrier: 0,
   gridX: 1,
@@ -66,11 +75,14 @@ aspirationEngine.setBattleSimulator(battleSimulator);
 aspirationEngine.initializeUnits([defender, ally, attacker]);
 
 const beforeAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
+const originalRandom = Math.random;
+Math.random = () => 0.99;
 mbtiRevengeEngine.handleAttack(attacker, defender, { type: 'ACTIVE' });
+Math.random = originalRandom;
 const afterAsp = aspirationEngine.getAspirationData(ally.uniqueId).aspiration;
 
 assert.strictEqual(afterAsp, beforeAsp - 10, 'Aspiration should decrease by 10');
-assert(attacker.currentHp < 100, 'Attacker should take damage');
+assert.strictEqual(attacker.currentHp, 80, 'Attacker should take damage based on highest stat');
 assert(animationCalled, 'Animation should trigger');
 
 console.log('MBTI Revenge Engine test passed');


### PR DESCRIPTION
## Summary
- allow CombatCalculationEngine to use a custom attack stat
- have MBTI chain and revenge attacks use whichever offensive stat is highest
- extend tests to verify damage scales with the top stat

## Testing
- `node tests/mbti_chain_attack_engine_test.js`
- `node tests/mbti_revenge_engine_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab4543c8a883278a9ad18792e43023