### PR TITLE
Fix NaN damage on active skills

### DIFF
--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -194,7 +194,14 @@ class CombatCalculationEngine {
 
         const finalDefense = initialDefense * (1 + defenseReductionPercent) * (1 - armorPen);
 
-        const damageMultiplier = (finalSkill.damageMultiplier || 1.0) * bonusMultiplier;
+        // --- 기본 데미지 배율을 안전하게 계산합니다. ---
+        let baseMultiplier = finalSkill.damageMultiplier;
+        if (typeof baseMultiplier === 'object') {
+            const { min = 1, max = 1 } = baseMultiplier;
+            baseMultiplier = (min + max) / 2;
+        }
+        const damageMultiplier = (baseMultiplier ?? 1.0) * bonusMultiplier;
+
         // ✨ 2. 증폭된 공격력을 기반으로 스킬 데미지를 계산합니다.
         const skillDamage = amplifiedAttack * damageMultiplier;
 

--- a/tests/combat_calculation_test.js
+++ b/tests/combat_calculation_test.js
@@ -78,4 +78,10 @@ console.log('✅ 테스트 3 통과: 공격력 버프가 정상적으로 적용�
 
 statusEffectManager.activeEffects.clear(); // 테스트 후 상태 초기화
 
+// 4. 데미지 범위를 가진 스킬 처리 테스트
+const rangedSkill = { name: 'Random Strike', tags: ['물리'], damageMultiplier: { min: 0.8, max: 1.2 } };
+result = combatCalculationEngine.calculateDamage(mockWarrior, mockZombie, rangedSkill);
+assert.strictEqual(result.damage, 18, '테스트 4 실패: 범위 데미지 스킬 계산이 올바르지 않습니다.');
+console.log('✅ 테스트 4 통과: 데미지 범위를 가진 스킬도 정상 처리됩니다.');
+
 console.log('--- 모든 전투 계산 테스트 완료 ---');


### PR DESCRIPTION
## Summary
- prevent NaN damage when active skills use ranged multipliers
- cover damage multiplier ranges with a new combat calculation test

## Testing
- `node tests/combat_calculation_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` and `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68af46c934348327b70d7a90ba8d754d