### PR TITLE
feat: introduce mercenary trait system

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1628,6 +1628,26 @@ body {
     border-radius: 12px;
 }
 
+.trait-tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+    padding: 6px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+    width: 100%;
+}
+
+.trait-tag {
+    background-color: rgba(59, 130, 246, 0.2);
+    border: 1px solid rgba(59, 130, 246, 0.6);
+    color: #3b82f6;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 12px;
+}
+
 #active-synergy-container {
     position: absolute;
     top: 20px;

--- a/src/game/data/traits.js
+++ b/src/game/data/traits.js
@@ -1,0 +1,76 @@
+export const traits = {
+    sturdy: {
+        id: 'sturdy',
+        name: '단단함',
+        description: '방어력 5% 상승',
+        apply: (stats) => {
+            stats.physicalDefense = (stats.physicalDefense || 0) * 1.05;
+        }
+    },
+    healthy: {
+        id: 'healthy',
+        name: '건강함',
+        description: '최대 체력 7% 상승',
+        apply: (stats) => {
+            stats.hp = (stats.hp || 0) * 1.07;
+        }
+    },
+    sharp: {
+        id: 'sharp',
+        name: '예리함',
+        description: '치명타율 5% 상승',
+        apply: (stats) => {
+            stats.criticalChance = (stats.criticalChance || 0) + 5;
+        }
+    },
+    clever: {
+        id: 'clever',
+        name: '총명함',
+        description: '마법 공격력 5% 상승',
+        apply: (stats) => {
+            stats.magicAttack = (stats.magicAttack || 0) * 1.05;
+        }
+    },
+    mighty: {
+        id: 'mighty',
+        name: '강인함',
+        description: '근접 공격력 5% 상승',
+        apply: (stats) => {
+            stats.physicalAttack = (stats.physicalAttack || 0) * 1.05;
+        }
+    },
+    marksman: {
+        id: 'marksman',
+        name: '명사수',
+        description: '원거리 공격력 5% 상승',
+        apply: (stats) => {
+            stats.rangedAttack = (stats.rangedAttack || 0) * 1.05;
+        }
+    },
+    devout: {
+        id: 'devout',
+        name: '신실함',
+        description: '마법 방어력 5% 상승',
+        apply: (stats) => {
+            stats.magicDefense = (stats.magicDefense || 0) * 1.05;
+        }
+    },
+    lucky: {
+        id: 'lucky',
+        name: '행운아',
+        description: '운 3% 상승',
+        apply: (stats) => {
+            stats.luck = (stats.luck || 0) * 1.03;
+        }
+    }
+};
+
+export function applyTraits(stats, traitIds = []) {
+    traitIds.forEach(id => {
+        const trait = traits[id];
+        if (trait && typeof trait.apply === 'function') {
+            trait.apply(stats);
+        }
+    });
+    return stats;
+}

--- a/src/game/debug/BirthReportManager.js
+++ b/src/game/debug/BirthReportManager.js
@@ -1,6 +1,7 @@
 import { debugLogEngine } from '../utils/DebugLogEngine.js';
 // 스킬 디버그 매니저를 import 합니다.
 import { debugSkillManager } from './DebugSkillManager.js';
+import { traits } from '../data/traits.js';
 
 /**
  * 새로 생성된 모든 유닛(아군, 적군)의 데이터를 콘솔에 기록하는 매니저
@@ -32,6 +33,17 @@ class BirthReportManager {
         debugLogEngine.log(this.name, `이름: ${unitInstance.instanceName}`);
         debugLogEngine.log(this.name, `클래스: ${unitInstance.name}`);
         debugLogEngine.log(this.name, `레벨: ${unitInstance.level}`);
+
+        if (unitInstance.traits && unitInstance.traits.length > 0) {
+            console.groupCollapsed(`%c[${this.name}] 특성`, `color: #a855f7; font-weight: bold;`);
+            unitInstance.traits.forEach(id => {
+                const t = traits[id];
+                if (t) {
+                    debugLogEngine.log(this.name, `${t.name}: ${t.description}`);
+                }
+            });
+            console.groupEnd();
+        }
 
         // 스킬 슬롯 정보를 로그로 남깁니다.
         if (unitInstance.skillSlots) {

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -14,6 +14,7 @@ import { fateSynergies } from '../data/synergies.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { synergyEngine } from '../utils/SynergyEngine.js';
 import { SynergyTooltipManager } from './SynergyTooltipManager.js';
+import { traits, applyTraits } from '../data/traits.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -21,6 +22,7 @@ import { SynergyTooltipManager } from './SynergyTooltipManager.js';
 export class UnitDetailDOM {
     static create(unitData) {
         const finalStats = statEngine.calculateStats(unitData, unitData.baseStats, []);
+        applyTraits(finalStats, unitData.traits);
         // ✨ 해당 유닛의 등급 데이터를 가져옵니다.
         const grades = classGrades[unitData.id] || {};
         // ✨ 2. 현재 유닛의 숙련도 태그 목록을 가져옵니다.
@@ -30,9 +32,14 @@ export class UnitDetailDOM {
         // ✨ 1. 용병의 고유 속성 특화 정보를 가져옵니다.
         const attributeSpec = unitData.attributeSpec;
         const synergies = unitData.synergies || {};
+        const unitTraits = unitData.traits || [];
         const deployed = partyEngine.getDeployedMercenaries();
         const fateSummary = synergyEngine.getFateSynergySummary(deployed);
         const activeFateCount = synergies.fate ? (fateSummary.find(s => s.key === synergies.fate)?.count || 0) : 0;
+        const traitTags = unitTraits.map(id => {
+            const t = traits[id];
+            return t ? `<span class="trait-tag" data-tooltip="${t.description}">${t.name}</span>` : '';
+        }).join('');
 
         // --- MBTI 문자열과 툴팁 텍스트를 준비합니다. ---
         const mbti = unitData.mbti;
@@ -167,6 +174,12 @@ export class UnitDetailDOM {
                 </div>
             </div>
         `;
+        const traitSectionHTML = `
+            <div class="trait-section">
+                <div class="section-title">특성</div>
+                <div class="trait-tags-container">${traitTags}</div>
+            </div>
+        `;
         const synergySectionHTML = `
             <div class="synergy-section">
                 <div class="section-title">시너지</div>
@@ -181,6 +194,7 @@ export class UnitDetailDOM {
         // =======================================================================
         leftSection.innerHTML = `
             ${gradeDisplayHTML}
+            ${traitSectionHTML}
             ${statsContainerHTML}
             ${synergySectionHTML}
         `;

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -14,6 +14,8 @@ import { CLASS_MBTI_MAP, mbtiFromString } from '../data/classMbtiMap.js';
 // ✨ [신규] 운명 시너지와 시너지 엔진을 가져옵니다.
 import { fateSynergies } from '../data/synergies.js';
 import { synergyEngine } from './SynergyEngine.js';
+// ✨ [신규] 특성 데이터를 가져옵니다.
+import { traits, applyTraits } from '../data/traits.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -91,9 +93,14 @@ class MercenaryEngine {
             attribute: randomAttribute ? randomAttribute.tag : null
         };
 
+        // ✨ [신규] 용병 생성 시 두 가지 무작위 특성을 부여합니다.
+        const traitKeys = Object.keys(traits);
+        newInstance.traits = diceEngine.getRandomElement(traitKeys, 2);
+
         // ✨ 모든 클래스가 동일한 슬롯 구조를 사용하므로 추가 로직이 필요 없습니다.
 
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
+        applyTraits(newInstance.finalStats, newInstance.traits);
 
         if (type === 'ally') {
             this.alliedMercenaries.set(uniqueId, newInstance);

--- a/tests/trait_system_test.js
+++ b/tests/trait_system_test.js
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { applyTraits } from '../src/game/data/traits.js';
+
+function base() {
+    return {
+        hp: 100,
+        physicalDefense: 100,
+        criticalChance: 10,
+        magicAttack: 100,
+        physicalAttack: 100,
+        rangedAttack: 100,
+        magicDefense: 100,
+        luck: 100
+    };
+}
+
+let stats = base();
+applyTraits(stats, ['sturdy']);
+assert.strictEqual(Math.round(stats.physicalDefense), 105);
+
+stats = base();
+applyTraits(stats, ['healthy']);
+assert.strictEqual(Math.round(stats.hp), 107);
+
+stats = base();
+applyTraits(stats, ['sharp']);
+assert.strictEqual(Math.round(stats.criticalChance), 15);
+
+stats = base();
+applyTraits(stats, ['clever']);
+assert.strictEqual(Math.round(stats.magicAttack), 105);
+
+stats = base();
+applyTraits(stats, ['mighty']);
+assert.strictEqual(Math.round(stats.physicalAttack), 105);
+
+stats = base();
+applyTraits(stats, ['marksman']);
+assert.strictEqual(Math.round(stats.rangedAttack), 105);
+
+stats = base();
+applyTraits(stats, ['devout']);
+assert.strictEqual(Math.round(stats.magicDefense), 105);
+
+stats = base();
+applyTraits(stats, ['lucky']);
+assert.strictEqual(Math.round(stats.luck), 103);
+
+console.log('Trait system tests passed.');


### PR DESCRIPTION
## Summary
- add random trait system granting two traits on mercenary creation
- log mercenary traits in debug and show in unit detail UI
- style trait tags and test trait effects

## Testing
- `node tests/trait_system_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68af4b7b0f9883279b3b9c4bc0a7eafa