### PR TITLE
fix: ensure unit stats and synergy fit within detail modal

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -317,7 +317,7 @@ body {
 #unit-detail-pane {
     /* 가로형 레이아웃을 위해 크기 조정 */
     width: 1000px;
-    height: 550px;
+    height: 620px;
     background-color: #2c2a29;
     border: 3px solid #1a1817;
     border-radius: 8px;
@@ -370,6 +370,7 @@ body {
 }
 .detail-section.left {
     width: 50%;
+    overflow-y: auto;
 }
 .detail-section.right {
     width: 50%;
@@ -1488,7 +1489,7 @@ body {
 
 .unit-portrait {
     width: 250px; /* 기존보다 너비 약간 축소 */
-    height: 300px;
+    height: 280px;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center top;


### PR DESCRIPTION
## Summary
- enlarge unit detail modal and allow scrolling so stats don't overflow
- shrink portrait height for better vertical space

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68af4f60814c8327acb24856c0d4e61d